### PR TITLE
Added more device targets, corrected all find_vm_kernel_addrperm values

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ iOS 9.3.5 is not supported.
 
 Supported device targets:
 * iPhone5,2 (N42AP), iOS 9.2.1 (Dillon 13D15)
+* iPhone4,1 (N94AP), iOS 9.3 (Eagle 13E233)
+* iPhone4,1 (N94AP), iOS 9.3 (Eagle 13E237)
 * iPhone4,1 (N94AP), iOS 9.3.1 (Eagle 13E238)
 * iPhone4,1 (N94AP), iOS 9.3.2 (Frisco 13F69)
 * iPhone4,1 (N94AP), iOS 9.3.3 (Genoa 13G34)

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -199,19 +199,19 @@ uint32_t find_write_gadget(void) {
 
 uint32_t find_vm_kernel_addrperm(void) {
 	switch (target_environment) {
-		case iPhone52_iOS921: return 0x455968;
-		case iPhone41_iOS930: return 0x455848;
-		case iPhone41_iOS931: return 0x455848;
-		case iPhone41_iOS932: return 0x455848;
-		case iPhone41_iOS933: return 0x455848;
-		case iPhone41_iOS934: return 0x455848;
-		case iPhone52_iOS932: return 0x45d97c;
-		case iPhone53_iOS932: return 0x45d97c;
-		case iPad21_iOS932: return 0x455848;
-		case iPad22_iOS932: return 0x455848;
-		case iPad23_iOS932: return 0x455848;
-		case iPad24_iOS932: return 0x455848;
-		case iPad23_iOS933: return 0x455848;
+		case iPhone52_iOS921: return 0x455964;
+		case iPhone41_iOS930: return 0x455844;
+		case iPhone41_iOS931: return 0x455844;
+		case iPhone41_iOS932: return 0x455844;
+		case iPhone41_iOS933: return 0x455844;
+		case iPhone41_iOS934: return 0x455844;
+		case iPhone52_iOS932: return 0x45d978;
+		case iPhone53_iOS932: return 0x45d978;
+		case iPad21_iOS932: return 0x455844;
+		case iPad22_iOS932: return 0x455844;
+		case iPad23_iOS932: return 0x455844;
+		case iPad24_iOS932: return 0x455844;
+		case iPad23_iOS933: return 0x455844;
 		case iPad31_iOS934: return 0x455844;
 		default: abort();
 	}

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -17,6 +17,7 @@ t_target_environment target_environment = NotSupported;
 
 t_target_environment info_to_target_environment(const char *device_model, const char *system_version) {
 	determineTarget("iPhone5,2", "9.2.1", iPhone52_iOS921);
+	determineTarget("iPhone4,1", "9.3", iPhone41_iOS930);
 	determineTarget("iPhone4,1", "9.3.1", iPhone41_iOS931);
 	determineTarget("iPhone4,1", "9.3.2", iPhone41_iOS932);
 	determineTarget("iPhone4,1", "9.3.3", iPhone41_iOS933);
@@ -39,6 +40,7 @@ void init_target_environment(const char *device_model, const char *system_versio
 uint32_t find_OSSerializer_serialize(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x317868;
+		case iPhone41_iOS930: return 0x31812c;
 		case iPhone41_iOS931: return 0x31812c;
 		case iPhone41_iOS932: return 0x318264;
 		case iPhone41_iOS933: return 0x318388;
@@ -58,6 +60,7 @@ uint32_t find_OSSerializer_serialize(void) {
 uint32_t find_OSSymbol_getMetaClass(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x319fa0;
+		case iPhone41_iOS930: return 0x31a934;
 		case iPhone41_iOS931: return 0x31a934;
 		case iPhone41_iOS932: return 0x31aa6c;
 		case iPhone41_iOS933: return 0x31ab90;
@@ -77,6 +80,7 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 uint32_t find_calend_gettime(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x1eb88;
+		case iPhone41_iOS930: return 0x1e170;
 		case iPhone41_iOS931: return 0x1e170;
 		case iPhone41_iOS932: return 0x1e170;
 		case iPhone41_iOS933: return 0x1e200;
@@ -96,6 +100,7 @@ uint32_t find_calend_gettime(void) {
 uint32_t find_bufattr_cpx(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0xdd9dc;
+		case iPhone41_iOS930: return 0xd9848;
 		case iPhone41_iOS931: return 0xd9848;
 		case iPhone41_iOS932: return 0xd9848;
 		case iPhone41_iOS933: return 0xd9838;
@@ -115,6 +120,7 @@ uint32_t find_bufattr_cpx(void) {
 uint32_t find_clock_ops(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x4033dc;
+		case iPhone41_iOS930: return 0x403428;
 		case iPhone41_iOS931: return 0x403428;
 		case iPhone41_iOS932: return 0x403428;
 		case iPhone41_iOS933: return 0x403428;
@@ -134,6 +140,7 @@ uint32_t find_clock_ops(void) {
 uint32_t find_copyin(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0xca87c;
+		case iPhone41_iOS930: return 0xc76b4;
 		case iPhone41_iOS931: return 0xc76b4;
 		case iPhone41_iOS932: return 0xc76b4;
 		case iPhone41_iOS933: return 0xc76b4;
@@ -153,6 +160,7 @@ uint32_t find_copyin(void) {
 uint32_t find_bx_lr(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0xdd9de;
+		case iPhone41_iOS930: return 0xd984a;
 		case iPhone41_iOS931: return 0xd984a;
 		case iPhone41_iOS932: return 0xd984a;
 		case iPhone41_iOS933: return 0xd983a;
@@ -172,6 +180,7 @@ uint32_t find_bx_lr(void) {
 uint32_t find_write_gadget(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0xca5a8;
+		case iPhone41_iOS930: return 0xc73e8;
 		case iPhone41_iOS931: return 0xc73e8;
 		case iPhone41_iOS932: return 0xc73e8;
 		case iPhone41_iOS933: return 0xc73e8;
@@ -191,6 +200,7 @@ uint32_t find_write_gadget(void) {
 uint32_t find_vm_kernel_addrperm(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x455968;
+		case iPhone41_iOS930: return 0x455848;
 		case iPhone41_iOS931: return 0x455848;
 		case iPhone41_iOS932: return 0x455848;
 		case iPhone41_iOS933: return 0x455848;
@@ -210,6 +220,7 @@ uint32_t find_vm_kernel_addrperm(void) {
 uint32_t find_kernel_pmap(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x3f6444;
+		case iPhone41_iOS930: return 0x3f6454;
 		case iPhone41_iOS931: return 0x3f6454;
 		case iPhone41_iOS932: return 0x3f6454;
 		case iPhone41_iOS933: return 0x3f6454;
@@ -229,6 +240,7 @@ uint32_t find_kernel_pmap(void) {
 uint32_t find_flush_dcache(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0xbe610;
+		case iPhone41_iOS930: return 0xbc250;
 		case iPhone41_iOS931: return 0xbc250;
 		case iPhone41_iOS932: return 0xbc260;
 		case iPhone41_iOS933: return 0xbc1d4;
@@ -248,6 +260,7 @@ uint32_t find_flush_dcache(void) {
 uint32_t find_invalidate_tlb(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0xca600;
+		case iPhone41_iOS930: return 0xc7440;
 		case iPhone41_iOS931: return 0xc7440;
 		case iPhone41_iOS932: return 0xc7440;
 		case iPhone41_iOS933: return 0xc7440;
@@ -267,6 +280,7 @@ uint32_t find_invalidate_tlb(void) {
 uint32_t find_task_for_pid(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x2fbc9c;
+		case iPhone41_iOS930: return 0x2fcc8c;
 		case iPhone41_iOS931: return 0x2fcc8c;
 		case iPhone41_iOS932: return 0x2fcd80;
 		case iPhone41_iOS933: return 0x2fcec0;
@@ -286,6 +300,7 @@ uint32_t find_task_for_pid(void) {
 uint32_t find_setreuid(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x2a9f34;
+		case iPhone41_iOS930: return 0x2a977c;
 		case iPhone41_iOS931: return 0x2a977c;
 		case iPhone41_iOS932: return 0x2a985c;
 		case iPhone41_iOS933: return 0x2a9988;
@@ -305,6 +320,7 @@ uint32_t find_setreuid(void) {
 uint32_t find_pid_check(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x16;
+		case iPhone41_iOS930: return 0x14;
 		case iPhone41_iOS931: return 0x14;
 		case iPhone41_iOS932: return 0x14;
 		case iPhone41_iOS933: return 0x14;
@@ -324,6 +340,7 @@ uint32_t find_pid_check(void) {
 uint32_t find_posix_check(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x3e;
+		case iPhone41_iOS930: return 0x3e;
 		case iPhone41_iOS931: return 0x3e;
 		case iPhone41_iOS932: return 0x3e;
 		case iPhone41_iOS933: return 0x3e;
@@ -343,6 +360,7 @@ uint32_t find_posix_check(void) {
 uint32_t find_mac_proc_check(void) {
 	switch (target_environment) {
 		case iPhone52_iOS921: return 0x1e6;
+		case iPhone41_iOS930: return 0x1e6;
 		case iPhone41_iOS931: return 0x1e6;
 		case iPhone41_iOS932: return 0x1e6;
 		case iPhone41_iOS933: return 0x1e6;

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -24,6 +24,7 @@ t_target_environment info_to_target_environment(const char *device_model, const 
 	determineTarget("iPhone4,1", "9.3.4", iPhone41_iOS934);
 	determineTarget("iPhone5,2", "9.3.2", iPhone52_iOS932);
 	determineTarget("iPhone5,3", "9.3.2", iPhone53_iOS932);
+	determineTarget("iPhone5,3", "9.3.3", iPhone53_iOS933);
 	determineTarget("iPad2,1", "9.3.2", iPad21_iOS932);
 	determineTarget("iPad2,2", "9.3.2", iPad22_iOS932);
 	determineTarget("iPad2,3", "9.3.2", iPad23_iOS932);
@@ -47,6 +48,7 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPhone41_iOS934: return 0x318388;
 		case iPhone52_iOS932: return 0x31ef58;
 		case iPhone53_iOS932: return 0x31ef58;
+		case iPhone53_iOS933: return 0x31f13c;
 		case iPad21_iOS932: return 0x318264;
 		case iPad22_iOS932: return 0x318264;
 		case iPad23_iOS932: return 0x318264;
@@ -67,6 +69,7 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 		case iPhone41_iOS934: return 0x31ab90;
 		case iPhone52_iOS932: return 0x322818;
 		case iPhone53_iOS932: return 0x322818;
+		case iPhone53_iOS933: return 0x3219fc;
 		case iPad21_iOS932: return 0x31aa6c;
 		case iPad22_iOS932: return 0x31aa6c;
 		case iPad23_iOS932: return 0x31aa6c;
@@ -87,6 +90,7 @@ uint32_t find_calend_gettime(void) {
 		case iPhone41_iOS934: return 0x1e200;
 		case iPhone52_iOS932: return 0x1e170;
 		case iPhone53_iOS932: return 0x1e170;
+		case iPhone53_iOS933: return 0x1eeac;
 		case iPad21_iOS932: return 0x1e170;
 		case iPad22_iOS932: return 0x1e170;
 		case iPad23_iOS932: return 0x1e170;
@@ -107,6 +111,7 @@ uint32_t find_bufattr_cpx(void) {
 		case iPhone41_iOS934: return 0xd9838;
 		case iPhone52_iOS932: return 0xdee6c;
 		case iPhone53_iOS932: return 0xdee6c;
+		case iPhone53_iOS933: return 0xdea48;
 		case iPad21_iOS932: return 0xd9848;
 		case iPad22_iOS932: return 0xd9848;
 		case iPad23_iOS932: return 0xd9848;
@@ -127,6 +132,7 @@ uint32_t find_clock_ops(void) {
 		case iPhone41_iOS934: return 0x403428;
 		case iPhone52_iOS932: return 0x40b428;
 		case iPhone53_iOS932: return 0x40b428;
+		case iPhone53_iOS933: return 0x40b428;
 		case iPad21_iOS932: return 0x403428;
 		case iPad22_iOS932: return 0x403428;
 		case iPad23_iOS932: return 0x403428;
@@ -147,6 +153,7 @@ uint32_t find_copyin(void) {
 		case iPhone41_iOS934: return 0xc76b4;
 		case iPhone52_iOS932: return 0xcb7dc;
 		case iPhone53_iOS932: return 0xcb7dc;
+		case iPhone53_iOS933: return 0xcb7dc;
 		case iPad21_iOS932: return 0xc76b4;
 		case iPad22_iOS932: return 0xc76b4;
 		case iPad23_iOS932: return 0xc76b4;
@@ -167,6 +174,7 @@ uint32_t find_bx_lr(void) {
 		case iPhone41_iOS934: return 0xd983a;
 		case iPhone52_iOS932: return 0xdea4a;
 		case iPhone53_iOS932: return 0xdea4a;
+		case iPhone53_iOS933: return 0xdea4a;
 		case iPad21_iOS932: return 0xd984a;
 		case iPad22_iOS932: return 0xd984a;
 		case iPad23_iOS932: return 0xd984a;
@@ -187,6 +195,7 @@ uint32_t find_write_gadget(void) {
 		case iPhone41_iOS934: return 0xc73e8;
 		case iPhone52_iOS932: return 0xcb508;
 		case iPhone53_iOS932: return 0xcb508;
+		case iPhone53_iOS933: return 0xcb508;
 		case iPad21_iOS932: return 0xc73e8;
 		case iPad22_iOS932: return 0xc73e8;
 		case iPad23_iOS932: return 0xc73e8;
@@ -207,6 +216,7 @@ uint32_t find_vm_kernel_addrperm(void) {
 		case iPhone41_iOS934: return 0x455844;
 		case iPhone52_iOS932: return 0x45d978;
 		case iPhone53_iOS932: return 0x45d978;
+		case iPhone53_iOS933: return 0x45d978;
 		case iPad21_iOS932: return 0x455844;
 		case iPad22_iOS932: return 0x455844;
 		case iPad23_iOS932: return 0x455844;
@@ -227,6 +237,7 @@ uint32_t find_kernel_pmap(void) {
 		case iPhone41_iOS934: return 0x3f6454;
 		case iPhone52_iOS932: return 0x3fe454;
 		case iPhone53_iOS932: return 0x3fe454;
+		case iPhone53_iOS933: return 0x3fe454;
 		case iPad21_iOS932: return 0x3f6454;
 		case iPad22_iOS932: return 0x3f6454;
 		case iPad23_iOS932: return 0x3f6454;
@@ -247,6 +258,7 @@ uint32_t find_flush_dcache(void) {
 		case iPhone41_iOS934: return 0xbc1d4;
 		case iPhone52_iOS932: return 0xbf274;
 		case iPhone53_iOS932: return 0xbf274;
+		case iPhone53_iOS933: return 0xbf404;
 		case iPad21_iOS932: return 0xbc260;
 		case iPad22_iOS932: return 0xbc260;
 		case iPad23_iOS932: return 0xbc260;
@@ -267,6 +279,7 @@ uint32_t find_invalidate_tlb(void) {
 		case iPhone41_iOS934: return 0xc7440;
 		case iPhone52_iOS932: return 0xcb560;
 		case iPhone53_iOS932: return 0xcb560;
+		case iPhone53_iOS933: return 0xcb560;
 		case iPad21_iOS932: return 0xc7440;
 		case iPad22_iOS932: return 0xc7440;
 		case iPad23_iOS932: return 0xc7440;
@@ -287,6 +300,7 @@ uint32_t find_task_for_pid(void) {
 		case iPhone41_iOS934: return 0x2fcec0;
 		case iPhone52_iOS932: return 0x302df0;
 		case iPhone53_iOS932: return 0x302df0;
+		case iPhone53_iOS933: return 0x302fd4;
 		case iPad21_iOS932: return 0x2fcd80;
 		case iPad22_iOS932: return 0x2fcd80;
 		case iPad23_iOS932: return 0x2fcd80;
@@ -307,6 +321,7 @@ uint32_t find_setreuid(void) {
 		case iPhone41_iOS934: return 0x2a9988;
 		case iPhone52_iOS932: return 0x2af5f8;
 		case iPhone53_iOS932: return 0x2af5f8;
+		case iPhone53_iOS933: return 0x2af7b8;
 		case iPad21_iOS932: return 0x2a985c;
 		case iPad22_iOS932: return 0x2a985c;
 		case iPad23_iOS932: return 0x2a985c;
@@ -327,6 +342,7 @@ uint32_t find_pid_check(void) {
 		case iPhone41_iOS934: return 0x14;
 		case iPhone52_iOS932: return 0x16;
 		case iPhone53_iOS932: return 0x16;
+		case iPhone53_iOS933: return 0x16;
 		case iPad21_iOS932: return 0x14;
 		case iPad22_iOS932: return 0x14;
 		case iPad23_iOS932: return 0x14;
@@ -347,6 +363,7 @@ uint32_t find_posix_check(void) {
 		case iPhone41_iOS934: return 0x3e;
 		case iPhone52_iOS932: return 0x3e;
 		case iPhone53_iOS932: return 0x3e;
+		case iPhone53_iOS933: return 0x3e;
 		case iPad21_iOS932: return 0x3e;
 		case iPad22_iOS932: return 0x3e;
 		case iPad23_iOS932: return 0x3e;
@@ -367,6 +384,7 @@ uint32_t find_mac_proc_check(void) {
 		case iPhone41_iOS934: return 0x1e6;
 		case iPhone52_iOS932: return 0x1e6;
 		case iPhone53_iOS932: return 0x1e6;
+		case iPhone53_iOS933: return 0x1e6;
 		case iPad21_iOS932: return 0x1e6;
 		case iPad22_iOS932: return 0x1e6;
 		case iPad23_iOS932: return 0x1e6;

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -14,6 +14,7 @@
 typedef enum {
 	NotSupported,
 	iPhone52_iOS921,
+	iPhone41_iOS930,
 	iPhone41_iOS931,
 	iPhone41_iOS932,
 	iPhone41_iOS933,

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -21,6 +21,7 @@ typedef enum {
 	iPhone41_iOS934,
 	iPhone52_iOS932,
 	iPhone53_iOS932,
+	iPhone53_iOS933,
 	iPad21_iOS932,
 	iPad22_iOS932,
 	iPad23_iOS932,


### PR DESCRIPTION
Added the iPhone41_iOS930 and iPhone53_iOS933 targets.

Note that there are two build numbers for iPhone4,1 iOS 9.3 — 13E233 and 13E237. However, the addresses are identical between both builds, so there is no need to differentiate between them in code.

Also fixed a severe issue where all the ported values returned by `find_vm_kernel_addrperm()` were higher by `0x4` due to changes in `exploit.c`. Addresses issue #10.