### PR TITLE
Support for iPad 3,2 iOS 9.3.2 and iPhone 5,1 iOS 9.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Supported device targets:
 * iPhone4,1 (N94AP), iOS 9.3.2 (Frisco 13F69)
 * iPhone4,1 (N94AP), iOS 9.3.3 (Genoa 13G34)
 * iPhone4,1 (N94AP), iOS 9.3.4 (Genoa 13G35)
+* iPhone5,1 (N41AP), iOS 9.3.2 (Frisco 13F69)
 * iPhone5,2 (N42AP), iOS 9.3.2 (Frisco 13F69)
 * iPhone5,3 (N48AP), iOS 9.3.2 (Frisco 13F69)
 * iPhone5,3 (N48AP), iOS 9.3.3 (Genoa 13G34)
@@ -26,6 +27,7 @@ Supported device targets:
 * iPad2,4 (K93AAP), iOS 9.3.2 (Frisco 13F69)
 * iPad2,3 (K95AP), iOS 9.3.3 (Genoa 13G34)
 * iPad3,1 (J1AP), iOS 9.3.4 (Genoa 13G35)
+* iPad3,2 (J2AP), iOS 9.3.2 (Eagle 13E238)
 * Want to contribute a device target? [Karen (angelXwind) wrote a tutorial on how to find addresses for Trident.](https://angelxwind.net/?page/trident-address-tutorial)
 
 References:

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -22,8 +22,8 @@ t_target_environment info_to_target_environment(const char *device_model, const 
 	determineTarget("iPad2,4", "9.3.2", iPad24_iOS932);
 	determineTarget("iPad2,3", "9.3.3", iPad23_iOS933);
 	determineTarget("iPad3,1", "9.3.4", iPad31_iOS934);
-    determineTarget("iPad3,2", "9.3.1", iPad32_iOS931);
-    return NotSupported;
+    	determineTarget("iPad3,2", "9.3.1", iPad32_iOS931);
+    	return NotSupported;
 }
 
 void init_target_environment(const char *device_model, const char *system_version) {
@@ -37,7 +37,7 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPhone41_iOS932: return 0x318264;
 		case iPhone41_iOS933: return 0x318388;
 		case iPhone41_iOS934: return 0x318388;
-		case iPhone51_iOS932: return 0x31ef46; //might be wrong?, try 0x31ef58
+		case iPhone51_iOS932: return 0x31ef46;
 		case iPhone52_iOS932: return 0x31ef58;
 		case iPhone53_iOS932: return 0x31ef58;
 		case iPad21_iOS932: return 0x318264;
@@ -46,8 +46,8 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPad24_iOS932: return 0x318264;
 		case iPad23_iOS933: return 0x318388;
 		case iPad31_iOS934: return 0x318388;
-        case iPad32_iOS931: return 0x31812c; //31712c
-        default: abort();
+        	case iPad32_iOS931: return 0x31812c;
+        	default: abort();
 	}
 }
 
@@ -67,8 +67,8 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 		case iPad24_iOS932: return 0x31aa6c;
 		case iPad23_iOS933: return 0x31ab90;
 		case iPad31_iOS934: return 0x31ab90;
-        case iPad32_iOS931: return 0x31a934;
-        default: abort();
+        	case iPad32_iOS931: return 0x31a934;
+        	default: abort();
 	}
 }
 
@@ -88,8 +88,8 @@ uint32_t find_calend_gettime(void) {
 		case iPad24_iOS932: return 0x1e170;
 		case iPad23_iOS933: return 0x1e200;
 		case iPad31_iOS934: return 0x1e200;
-        case iPad32_iOS931: return 0x1e170;
-        default: abort();
+        	case iPad32_iOS931: return 0x1e170;
+        	default: abort();
 	}
 }
 
@@ -109,8 +109,8 @@ uint32_t find_bufattr_cpx(void) {
 		case iPad24_iOS932: return 0xd9848;
 		case iPad23_iOS933: return 0xd9838;
 		case iPad31_iOS934: return 0xd9838;
-        case iPad32_iOS931: return 0xd9848;
-        default: abort();
+        	case iPad32_iOS931: return 0xd9848;
+        	default: abort();
 	}
 }
 
@@ -130,8 +130,8 @@ uint32_t find_clock_ops(void) {
 		case iPad24_iOS932: return 0x403428;
 		case iPad23_iOS933: return 0x403428;
 		case iPad31_iOS934: return 0x403428;
-        case iPad32_iOS931: return 0x403428;
-        default: abort();
+        	case iPad32_iOS931: return 0x403428;
+        	default: abort();
 	}
 }
 
@@ -151,8 +151,8 @@ uint32_t find_copyin(void) {
 		case iPad24_iOS932: return 0xc76b4;
 		case iPad23_iOS933: return 0xc76b4;
 		case iPad31_iOS934: return 0xc76b4;
-        case iPad32_iOS931: return 0xc76b4;
-        default: abort();
+        	case iPad32_iOS931: return 0xc76b4;
+        	default: abort();
 	}
 }
 
@@ -172,8 +172,8 @@ uint32_t find_bx_lr(void) {
 		case iPad24_iOS932: return 0xd984a;
 		case iPad23_iOS933: return 0xd983a;
 		case iPad31_iOS934: return 0xd983a;
-        case iPad32_iOS931: return 0xd984a;
-        default: abort();
+        	case iPad32_iOS931: return 0xd984a;
+        	default: abort();
 	}
 }
 
@@ -193,8 +193,8 @@ uint32_t find_write_gadget(void) {
 		case iPad24_iOS932: return 0xc73e8;
 		case iPad23_iOS933: return 0xc73e8;
 		case iPad31_iOS934: return 0xc73e8;
-        case iPad32_iOS931: return 0xc73e8;
-        default: abort();
+        	case iPad32_iOS931: return 0xc73e8;
+        	default: abort();
 	}
 }
 
@@ -214,7 +214,7 @@ uint32_t find_vm_kernel_addrperm(void) {
 		case iPad24_iOS932: return 0x455848;
 		case iPad23_iOS933: return 0x455848;
 		case iPad31_iOS934: return 0x455844;
-        case iPad32_iOS931: return 0x455844;
+        	case iPad32_iOS931: return 0x455844;
 		default: abort();
 	}
 }
@@ -235,8 +235,8 @@ uint32_t find_kernel_pmap(void) {
 		case iPad24_iOS932: return 0x3f6454;
 		case iPad23_iOS933: return 0x3f6454;
 		case iPad31_iOS934: return 0x3f6454;
-        case iPad32_iOS931: return 0x3f6454;
-        default: abort();
+        	case iPad32_iOS931: return 0x3f6454;
+        	default: abort();
 	}
 }
 
@@ -256,8 +256,8 @@ uint32_t find_flush_dcache(void) {
 		case iPad24_iOS932: return 0xbc260;
 		case iPad23_iOS933: return 0xbc1d8;
 		case iPad31_iOS934: return 0xbc1d4;
-        case iPad32_iOS931: return 0xbc250;
-        default: abort();
+        	case iPad32_iOS931: return 0xbc250;
+        	default: abort();
 	}
 }
 
@@ -277,8 +277,8 @@ uint32_t find_invalidate_tlb(void) {
 		case iPad24_iOS932: return 0xc7440;
 		case iPad23_iOS933: return 0xc7450;
 		case iPad31_iOS934: return 0xc7440;
-        case iPad32_iOS931: return 0xc7440;
-        default: abort();
+        	case iPad32_iOS931: return 0xc7440;
+        	default: abort();
 	}
 }
 
@@ -298,8 +298,8 @@ uint32_t find_task_for_pid(void) {
 		case iPad24_iOS932: return 0x2fcd80;
 		case iPad23_iOS933: return 0x2fcec0;
 		case iPad31_iOS934: return 0x2fcec0;
-        case iPad32_iOS931: return 0x2fcc8c;
-        default: abort();
+        	case iPad32_iOS931: return 0x2fcc8c;
+        	default: abort();
 	}
 }
 
@@ -318,8 +318,8 @@ uint32_t find_setreuid(void) {
 		case iPad24_iOS932: return 0x2a985c;
 		case iPad23_iOS933: return 0x2a9988;
 		case iPad31_iOS934: return 0x2a9988;
-        case iPad32_iOS931: return 0x2a977c;
-        default: abort();
+        	case iPad32_iOS931: return 0x2a977c;
+        	default: abort();
 	}
 }
 
@@ -338,8 +338,8 @@ uint32_t find_pid_check(void) {
 		case iPad24_iOS932: return 0x14;
 		case iPad23_iOS933: return 0x14;
 		case iPad31_iOS934: return 0x14;
-        case iPad32_iOS931: return 0x14;
-        default: abort();
+        	case iPad32_iOS931: return 0x14;
+        	default: abort();
 	}
 }
 
@@ -358,8 +358,8 @@ uint32_t find_posix_check(void) {
 		case iPad24_iOS932: return 0x3e;
 		case iPad23_iOS933: return 0x3e;
 		case iPad31_iOS934: return 0x3e;
-        case iPad32_iOS931: return 0x3e;
-        default: abort();
+        	case iPad32_iOS931: return 0x3e;
+        	default: abort();
 	}
 }
 
@@ -378,14 +378,7 @@ uint32_t find_mac_proc_check(void) {
 		case iPad24_iOS932: return 0x1e6;
 		case iPad23_iOS933: return 0x1e6;
 		case iPad31_iOS934: return 0x1e6;
-        case iPad32_iOS931: return 0x1e6;
-        default: abort();
-	}
-}
-
-uint32_t find_PE_i_can_has_debugger(void) {
-	switch (target_environment) {
-		case iPad32_iOS931: return 0x80388ADC; // LDR R1, [R1]
-		default: abort();
+        	case iPad32_iOS931: return 0x1e6;
+        	default: abort();
 	}
 }

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -1,11 +1,3 @@
-//
-//  offsetfinder.c
-//  Trident
-//
-//  Created by Benjamin Randazzo on 14/12/2016.
-//  Copyright © 2016 Benjamin Randazzo. All rights reserved.
-//
-
 #include "offsetfinder.h"
 
 #include <stdlib.h>
@@ -21,6 +13,7 @@ t_target_environment info_to_target_environment(const char *device_model, const 
 	determineTarget("iPhone4,1", "9.3.2", iPhone41_iOS932);
 	determineTarget("iPhone4,1", "9.3.3", iPhone41_iOS933);
 	determineTarget("iPhone4,1", "9.3.4", iPhone41_iOS934);
+	determineTarget("iPhone5,1", "9.3.2", iPhone51_iOS932);
 	determineTarget("iPhone5,2", "9.3.2", iPhone52_iOS932);
 	determineTarget("iPhone5,3", "9.3.2", iPhone53_iOS932);
 	determineTarget("iPad2,1", "9.3.2", iPad21_iOS932);
@@ -29,7 +22,8 @@ t_target_environment info_to_target_environment(const char *device_model, const 
 	determineTarget("iPad2,4", "9.3.2", iPad24_iOS932);
 	determineTarget("iPad2,3", "9.3.3", iPad23_iOS933);
 	determineTarget("iPad3,1", "9.3.4", iPad31_iOS934);
-	return NotSupported;
+    determineTarget("iPad3,2", "9.3.1", iPad32_iOS931);
+    return NotSupported;
 }
 
 void init_target_environment(const char *device_model, const char *system_version) {
@@ -43,6 +37,7 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPhone41_iOS932: return 0x318264;
 		case iPhone41_iOS933: return 0x318388;
 		case iPhone41_iOS934: return 0x318388;
+		case iPhone51_iOS932: return 0x31ef46; //might be wrong?, try 0x31ef58
 		case iPhone52_iOS932: return 0x31ef58;
 		case iPhone53_iOS932: return 0x31ef58;
 		case iPad21_iOS932: return 0x318264;
@@ -51,7 +46,8 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPad24_iOS932: return 0x318264;
 		case iPad23_iOS933: return 0x318388;
 		case iPad31_iOS934: return 0x318388;
-		default: abort();
+        case iPad32_iOS931: return 0x31812c; //31712c
+        default: abort();
 	}
 }
 
@@ -62,6 +58,7 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 		case iPhone41_iOS932: return 0x31aa6c;
 		case iPhone41_iOS933: return 0x31ab90;
 		case iPhone41_iOS934: return 0x31ab90;
+		case iPhone51_iOS932: return 0x321818;
 		case iPhone52_iOS932: return 0x322818;
 		case iPhone53_iOS932: return 0x322818;
 		case iPad21_iOS932: return 0x31aa6c;
@@ -70,7 +67,8 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 		case iPad24_iOS932: return 0x31aa6c;
 		case iPad23_iOS933: return 0x31ab90;
 		case iPad31_iOS934: return 0x31ab90;
-		default: abort();
+        case iPad32_iOS931: return 0x31a934;
+        default: abort();
 	}
 }
 
@@ -81,6 +79,7 @@ uint32_t find_calend_gettime(void) {
 		case iPhone41_iOS932: return 0x1e170;
 		case iPhone41_iOS933: return 0x1e200;
 		case iPhone41_iOS934: return 0x1e200;
+		case iPhone51_iOS932: return 0x1ee6c;
 		case iPhone52_iOS932: return 0x1e170;
 		case iPhone53_iOS932: return 0x1e170;
 		case iPad21_iOS932: return 0x1e170;
@@ -89,7 +88,8 @@ uint32_t find_calend_gettime(void) {
 		case iPad24_iOS932: return 0x1e170;
 		case iPad23_iOS933: return 0x1e200;
 		case iPad31_iOS934: return 0x1e200;
-		default: abort();
+        case iPad32_iOS931: return 0x1e170;
+        default: abort();
 	}
 }
 
@@ -100,6 +100,7 @@ uint32_t find_bufattr_cpx(void) {
 		case iPhone41_iOS932: return 0xd9848;
 		case iPhone41_iOS933: return 0xd9838;
 		case iPhone41_iOS934: return 0xd9838;
+		case iPhone51_iOS932: return 0xdea48;
 		case iPhone52_iOS932: return 0xdee6c;
 		case iPhone53_iOS932: return 0xdee6c;
 		case iPad21_iOS932: return 0xd9848;
@@ -108,7 +109,8 @@ uint32_t find_bufattr_cpx(void) {
 		case iPad24_iOS932: return 0xd9848;
 		case iPad23_iOS933: return 0xd9838;
 		case iPad31_iOS934: return 0xd9838;
-		default: abort();
+        case iPad32_iOS931: return 0xd9848;
+        default: abort();
 	}
 }
 
@@ -119,6 +121,7 @@ uint32_t find_clock_ops(void) {
 		case iPhone41_iOS932: return 0x403428;
 		case iPhone41_iOS933: return 0x403428;
 		case iPhone41_iOS934: return 0x403428;
+		case iPhone51_iOS932: return 0x40b654;
 		case iPhone52_iOS932: return 0x40b428;
 		case iPhone53_iOS932: return 0x40b428;
 		case iPad21_iOS932: return 0x403428;
@@ -127,7 +130,8 @@ uint32_t find_clock_ops(void) {
 		case iPad24_iOS932: return 0x403428;
 		case iPad23_iOS933: return 0x403428;
 		case iPad31_iOS934: return 0x403428;
-		default: abort();
+        case iPad32_iOS931: return 0x403428;
+        default: abort();
 	}
 }
 
@@ -138,6 +142,7 @@ uint32_t find_copyin(void) {
 		case iPhone41_iOS932: return 0xc76b4;
 		case iPhone41_iOS933: return 0xc76b4;
 		case iPhone41_iOS934: return 0xc76b4;
+		case iPhone51_iOS932: return 0xcb7dc;
 		case iPhone52_iOS932: return 0xcb7dc;
 		case iPhone53_iOS932: return 0xcb7dc;
 		case iPad21_iOS932: return 0xc76b4;
@@ -146,7 +151,8 @@ uint32_t find_copyin(void) {
 		case iPad24_iOS932: return 0xc76b4;
 		case iPad23_iOS933: return 0xc76b4;
 		case iPad31_iOS934: return 0xc76b4;
-		default: abort();
+        case iPad32_iOS931: return 0xc76b4;
+        default: abort();
 	}
 }
 
@@ -157,6 +163,7 @@ uint32_t find_bx_lr(void) {
 		case iPhone41_iOS932: return 0xd984a;
 		case iPhone41_iOS933: return 0xd983a;
 		case iPhone41_iOS934: return 0xd983a;
+		case iPhone51_iOS932: return 0xdea4a;
 		case iPhone52_iOS932: return 0xdea4a;
 		case iPhone53_iOS932: return 0xdea4a;
 		case iPad21_iOS932: return 0xd984a;
@@ -165,7 +172,8 @@ uint32_t find_bx_lr(void) {
 		case iPad24_iOS932: return 0xd984a;
 		case iPad23_iOS933: return 0xd983a;
 		case iPad31_iOS934: return 0xd983a;
-		default: abort();
+        case iPad32_iOS931: return 0xd984a;
+        default: abort();
 	}
 }
 
@@ -176,6 +184,7 @@ uint32_t find_write_gadget(void) {
 		case iPhone41_iOS932: return 0xc73e8;
 		case iPhone41_iOS933: return 0xc73e8;
 		case iPhone41_iOS934: return 0xc73e8;
+		case iPhone51_iOS932: return 0xcb508;
 		case iPhone52_iOS932: return 0xcb508;
 		case iPhone53_iOS932: return 0xcb508;
 		case iPad21_iOS932: return 0xc73e8;
@@ -184,7 +193,8 @@ uint32_t find_write_gadget(void) {
 		case iPad24_iOS932: return 0xc73e8;
 		case iPad23_iOS933: return 0xc73e8;
 		case iPad31_iOS934: return 0xc73e8;
-		default: abort();
+        case iPad32_iOS931: return 0xc73e8;
+        default: abort();
 	}
 }
 
@@ -195,6 +205,7 @@ uint32_t find_vm_kernel_addrperm(void) {
 		case iPhone41_iOS932: return 0x455848;
 		case iPhone41_iOS933: return 0x455848;
 		case iPhone41_iOS934: return 0x455848;
+		case iPhone51_iOS932: return 0x45d91c;
 		case iPhone52_iOS932: return 0x45d97c;
 		case iPhone53_iOS932: return 0x45d97c;
 		case iPad21_iOS932: return 0x455848;
@@ -203,6 +214,7 @@ uint32_t find_vm_kernel_addrperm(void) {
 		case iPad24_iOS932: return 0x455848;
 		case iPad23_iOS933: return 0x455848;
 		case iPad31_iOS934: return 0x455844;
+        case iPad32_iOS931: return 0x455844;
 		default: abort();
 	}
 }
@@ -214,6 +226,7 @@ uint32_t find_kernel_pmap(void) {
 		case iPhone41_iOS932: return 0x3f6454;
 		case iPhone41_iOS933: return 0x3f6454;
 		case iPhone41_iOS934: return 0x3f6454;
+		case iPhone51_iOS932: return 0x3fe454;
 		case iPhone52_iOS932: return 0x3fe454;
 		case iPhone53_iOS932: return 0x3fe454;
 		case iPad21_iOS932: return 0x3f6454;
@@ -222,7 +235,8 @@ uint32_t find_kernel_pmap(void) {
 		case iPad24_iOS932: return 0x3f6454;
 		case iPad23_iOS933: return 0x3f6454;
 		case iPad31_iOS934: return 0x3f6454;
-		default: abort();
+        case iPad32_iOS931: return 0x3f6454;
+        default: abort();
 	}
 }
 
@@ -233,6 +247,7 @@ uint32_t find_flush_dcache(void) {
 		case iPhone41_iOS932: return 0xbc260;
 		case iPhone41_iOS933: return 0xbc1d4;
 		case iPhone41_iOS934: return 0xbc1d4;
+		case iPhone51_iOS932: return 0xbf274;
 		case iPhone52_iOS932: return 0xbf274;
 		case iPhone53_iOS932: return 0xbf274;
 		case iPad21_iOS932: return 0xbc260;
@@ -241,7 +256,8 @@ uint32_t find_flush_dcache(void) {
 		case iPad24_iOS932: return 0xbc260;
 		case iPad23_iOS933: return 0xbc1d8;
 		case iPad31_iOS934: return 0xbc1d4;
-		default: abort();
+        case iPad32_iOS931: return 0xbc250;
+        default: abort();
 	}
 }
 
@@ -252,6 +268,7 @@ uint32_t find_invalidate_tlb(void) {
 		case iPhone41_iOS932: return 0xc7440;
 		case iPhone41_iOS933: return 0xc7440;
 		case iPhone41_iOS934: return 0xc7440;
+		case iPhone51_iOS932: return 0xcb560;
 		case iPhone52_iOS932: return 0xcb560;
 		case iPhone53_iOS932: return 0xcb560;
 		case iPad21_iOS932: return 0xc7440;
@@ -260,7 +277,8 @@ uint32_t find_invalidate_tlb(void) {
 		case iPad24_iOS932: return 0xc7440;
 		case iPad23_iOS933: return 0xc7450;
 		case iPad31_iOS934: return 0xc7440;
-		default: abort();
+        case iPad32_iOS931: return 0xc7440;
+        default: abort();
 	}
 }
 
@@ -271,6 +289,7 @@ uint32_t find_task_for_pid(void) {
 		case iPhone41_iOS932: return 0x2fcd80;
 		case iPhone41_iOS933: return 0x2fcec0;
 		case iPhone41_iOS934: return 0x2fcec0;
+		case iPhone51_iOS932: return 0x302df0;
 		case iPhone52_iOS932: return 0x302df0;
 		case iPhone53_iOS932: return 0x302df0;
 		case iPad21_iOS932: return 0x2fcd80;
@@ -279,7 +298,8 @@ uint32_t find_task_for_pid(void) {
 		case iPad24_iOS932: return 0x2fcd80;
 		case iPad23_iOS933: return 0x2fcec0;
 		case iPad31_iOS934: return 0x2fcec0;
-		default: abort();
+        case iPad32_iOS931: return 0x2fcc8c;
+        default: abort();
 	}
 }
 
@@ -298,7 +318,8 @@ uint32_t find_setreuid(void) {
 		case iPad24_iOS932: return 0x2a985c;
 		case iPad23_iOS933: return 0x2a9988;
 		case iPad31_iOS934: return 0x2a9988;
-		default: abort();
+        case iPad32_iOS931: return 0x2a977c;
+        default: abort();
 	}
 }
 
@@ -317,7 +338,8 @@ uint32_t find_pid_check(void) {
 		case iPad24_iOS932: return 0x14;
 		case iPad23_iOS933: return 0x14;
 		case iPad31_iOS934: return 0x14;
-		default: abort();
+        case iPad32_iOS931: return 0x14;
+        default: abort();
 	}
 }
 
@@ -336,7 +358,8 @@ uint32_t find_posix_check(void) {
 		case iPad24_iOS932: return 0x3e;
 		case iPad23_iOS933: return 0x3e;
 		case iPad31_iOS934: return 0x3e;
-		default: abort();
+        case iPad32_iOS931: return 0x3e;
+        default: abort();
 	}
 }
 
@@ -355,6 +378,14 @@ uint32_t find_mac_proc_check(void) {
 		case iPad24_iOS932: return 0x1e6;
 		case iPad23_iOS933: return 0x1e6;
 		case iPad31_iOS934: return 0x1e6;
+        case iPad32_iOS931: return 0x1e6;
+        default: abort();
+	}
+}
+
+uint32_t find_PE_i_can_has_debugger(void) {
+	switch (target_environment) {
+		case iPad32_iOS931: return 0x80388ADC; // LDR R1, [R1]
 		default: abort();
 	}
 }

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -1,3 +1,11 @@
+//
+//  offsetfinder.c
+//  Trident
+//
+//  Created by Benjamin Randazzo on 14/12/2016.
+//  Copyright © 2016 Benjamin Randazzo. All rights reserved.
+//
+
 #include "offsetfinder.h"
 
 #include <stdlib.h>

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -1,11 +1,3 @@
-//
-//  offsetfinder.h
-//  Trident
-//
-//  Created by Benjamin Randazzo on 14/12/2016.
-//  Copyright © 2016 Benjamin Randazzo. All rights reserved.
-//
-
 #ifndef offsetfinder_h
 #define offsetfinder_h
 
@@ -18,6 +10,7 @@ typedef enum {
 	iPhone41_iOS932,
 	iPhone41_iOS933,
 	iPhone41_iOS934,
+	iPhone51_iOS932,
 	iPhone52_iOS932,
 	iPhone53_iOS932,
 	iPad21_iOS932,
@@ -26,6 +19,7 @@ typedef enum {
 	iPad24_iOS932,
 	iPad23_iOS933,
 	iPad31_iOS934,
+    iPad32_iOS931
 } t_target_environment;
 
 extern t_target_environment target_environment;
@@ -83,5 +77,8 @@ uint32_t find_posix_check(void);
 
 // mac_proc_check_ret_addr offset
 uint32_t find_mac_proc_check(void);
+
+// PE_i_can_has_debugger offset
+uint32_t find_PE_i_can_has_debugger(void);
 
 #endif /* offsetfinder_h */

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -1,3 +1,11 @@
+//
+//  offsetfinder.h
+//  Trident
+//
+//  Created by Benjamin Randazzo on 14/12/2016.
+//  Copyright © 2016 Benjamin Randazzo. All rights reserved.
+//
+
 #ifndef offsetfinder_h
 #define offsetfinder_h
 

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -19,7 +19,7 @@ typedef enum {
 	iPad24_iOS932,
 	iPad23_iOS933,
 	iPad31_iOS934,
-    iPad32_iOS931
+    	iPad32_iOS931
 } t_target_environment;
 
 extern t_target_environment target_environment;
@@ -77,8 +77,5 @@ uint32_t find_posix_check(void);
 
 // mac_proc_check_ret_addr offset
 uint32_t find_mac_proc_check(void);
-
-// PE_i_can_has_debugger offset
-uint32_t find_PE_i_can_has_debugger(void);
 
 #endif /* offsetfinder_h */


### PR DESCRIPTION
Adds support for the iPhone5,1 (N41AP), iOS 9.3.2 (Frisco 13F69) and the iPad3,2 (J2AP), iOS 9.3.2 (Eagle 13E238). Also updated the README to add the devices to the supported list.