### PR TITLE
Add offsets for iPad2,1 9.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Supported devices:
 * iPhone5,2 (N42AP), iOS 9.3.2 (Frisco 13F69)
 * iPhone5,3 (N48AP), iOS 9.3.2 (Frisco 13F69)
 * iPhone5,3 (N48AP), iOS 9.3.3 (Genoa 13G34)
+* iPad2,1 (K93AP), iOS 9.3.1 (Eagle 13E238)
 * iPad2,1 (K93AP), iOS 9.3.2 (Frisco 13F69)
 * iPad2,2 (K94AP), iOS 9.3.2 (Frisco 13F69)
 * iPad2,3 (K95AP), iOS 9.3.2 (Frisco 13F69)

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -26,13 +26,14 @@ t_target_environment info_to_target_environment(const char *device_model, const 
 	determineTarget("iPhone5,2", "9.3.2", iPhone52_iOS932);
 	determineTarget("iPhone5,3", "9.3.2", iPhone53_iOS932);
 	determineTarget("iPhone5,3", "9.3.3", iPhone53_iOS933);
+	determineTarget("iPad2,1", "9.3.1", iPad21_iOS931);
 	determineTarget("iPad2,1", "9.3.2", iPad21_iOS932);
 	determineTarget("iPad2,2", "9.3.2", iPad22_iOS932);
 	determineTarget("iPad2,3", "9.3.2", iPad23_iOS932);
 	determineTarget("iPad2,4", "9.3.2", iPad24_iOS932);
 	determineTarget("iPad2,3", "9.3.3", iPad23_iOS933);
 	determineTarget("iPad3,1", "9.3.4", iPad31_iOS934);
-    determineTarget("iPad3,2", "9.3.1", iPad32_iOS931);
+	determineTarget("iPad3,2", "9.3.1", iPad32_iOS931);
 	determineTarget("iPod5,1", "9.3.2", iPod51_iOS932);
 	return NotSupported;
 }
@@ -53,13 +54,14 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPhone52_iOS932: return 0x31ef58;
 		case iPhone53_iOS932: return 0x31ef58;
 		case iPhone53_iOS933: return 0x31f13c;
+		case iPad21_iOS931: return 0x31812c;
 		case iPad21_iOS932: return 0x318264;
 		case iPad22_iOS932: return 0x318264;
 		case iPad23_iOS932: return 0x318264;
 		case iPad24_iOS932: return 0x318264;
 		case iPad23_iOS933: return 0x318388;
 		case iPad31_iOS934: return 0x318388;
-        case iPad32_iOS931: return 0x31812c;
+		case iPad32_iOS931: return 0x31812c;
 		case iPod51_iOS932: return 0x318264;
 		default: abort();
 	}
@@ -77,13 +79,14 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 		case iPhone52_iOS932: return 0x322818;
 		case iPhone53_iOS932: return 0x322818;
 		case iPhone53_iOS933: return 0x3219fc;
+		case iPad21_iOS931: return 0x31a934;
 		case iPad21_iOS932: return 0x31aa6c;
 		case iPad22_iOS932: return 0x31aa6c;
 		case iPad23_iOS932: return 0x31aa6c;
 		case iPad24_iOS932: return 0x31aa6c;
 		case iPad23_iOS933: return 0x31ab90;
 		case iPad31_iOS934: return 0x31ab90;
-        case iPad32_iOS931: return 0x31a934;
+		case iPad32_iOS931: return 0x31a934;
 		case iPod51_iOS932: return 0x31aa6c;
 		default: abort();
 	}
@@ -101,13 +104,14 @@ uint32_t find_calend_gettime(void) {
 		case iPhone52_iOS932: return 0x1e170;
 		case iPhone53_iOS932: return 0x1e170;
 		case iPhone53_iOS933: return 0x1eeac;
+		case iPad21_iOS931: return 0x1e170;
 		case iPad21_iOS932: return 0x1e170;
 		case iPad22_iOS932: return 0x1e170;
 		case iPad23_iOS932: return 0x1e170;
 		case iPad24_iOS932: return 0x1e170;
 		case iPad23_iOS933: return 0x1e200;
 		case iPad31_iOS934: return 0x1e200;
-        case iPad32_iOS931: return 0x1e170;
+		case iPad32_iOS931: return 0x1e170;
 		case iPod51_iOS932: return 0x1e170;
 		default: abort();
 	}
@@ -125,13 +129,14 @@ uint32_t find_bufattr_cpx(void) {
 		case iPhone52_iOS932: return 0xdee6c;
 		case iPhone53_iOS932: return 0xdee6c;
 		case iPhone53_iOS933: return 0xdea48;
+		case iPad21_iOS931: return 0xd9848;
 		case iPad21_iOS932: return 0xd9848;
 		case iPad22_iOS932: return 0xd9848;
 		case iPad23_iOS932: return 0xd9848;
 		case iPad24_iOS932: return 0xd9848;
 		case iPad23_iOS933: return 0xd9838;
 		case iPad31_iOS934: return 0xd9838;
-        case iPad32_iOS931: return 0xd9848;
+		case iPad32_iOS931: return 0xd9848;
 		case iPod51_iOS932: return 0xd9848;
 		default: abort();
 	}
@@ -149,13 +154,14 @@ uint32_t find_clock_ops(void) {
 		case iPhone52_iOS932: return 0x40b428;
 		case iPhone53_iOS932: return 0x40b428;
 		case iPhone53_iOS933: return 0x40b428;
+		case iPad21_iOS931: return 0x403428;
 		case iPad21_iOS932: return 0x403428;
 		case iPad22_iOS932: return 0x403428;
 		case iPad23_iOS932: return 0x403428;
 		case iPad24_iOS932: return 0x403428;
 		case iPad23_iOS933: return 0x403428;
 		case iPad31_iOS934: return 0x403428;
-        case iPad32_iOS931: return 0x403428;
+		case iPad32_iOS931: return 0x403428;
 		case iPod51_iOS932: return 0x403428;
 		default: abort();
 	}
@@ -173,13 +179,14 @@ uint32_t find_copyin(void) {
 		case iPhone52_iOS932: return 0xcb7dc;
 		case iPhone53_iOS932: return 0xcb7dc;
 		case iPhone53_iOS933: return 0xcb7dc;
+		case iPad21_iOS931: return 0xc76b4;
 		case iPad21_iOS932: return 0xc76b4;
 		case iPad22_iOS932: return 0xc76b4;
 		case iPad23_iOS932: return 0xc76b4;
 		case iPad24_iOS932: return 0xc76b4;
 		case iPad23_iOS933: return 0xc76b4;
 		case iPad31_iOS934: return 0xc76b4;
-        case iPad32_iOS931: return 0xc76b4;
+		case iPad32_iOS931: return 0xc76b4;
 		case iPod51_iOS932: return 0xc76b4;
 		default: abort();
 	}
@@ -197,13 +204,14 @@ uint32_t find_bx_lr(void) {
 		case iPhone52_iOS932: return 0xdea4a;
 		case iPhone53_iOS932: return 0xdea4a;
 		case iPhone53_iOS933: return 0xdea4a;
+		case iPad21_iOS931: return 0xd984a;
 		case iPad21_iOS932: return 0xd984a;
 		case iPad22_iOS932: return 0xd984a;
 		case iPad23_iOS932: return 0xd984a;
 		case iPad24_iOS932: return 0xd984a;
 		case iPad23_iOS933: return 0xd983a;
 		case iPad31_iOS934: return 0xd983a;
-        case iPad32_iOS931: return 0xd984a;
+		case iPad32_iOS931: return 0xd984a;
 		case iPod51_iOS932: return 0xd984a;
 		default: abort();
 	}
@@ -221,13 +229,14 @@ uint32_t find_write_gadget(void) {
 		case iPhone52_iOS932: return 0xcb508;
 		case iPhone53_iOS932: return 0xcb508;
 		case iPhone53_iOS933: return 0xcb508;
+		case iPad21_iOS931: return 0xc73e8;
 		case iPad21_iOS932: return 0xc73e8;
 		case iPad22_iOS932: return 0xc73e8;
 		case iPad23_iOS932: return 0xc73e8;
 		case iPad24_iOS932: return 0xc73e8;
 		case iPad23_iOS933: return 0xc73e8;
 		case iPad31_iOS934: return 0xc73e8;
-        case iPad32_iOS931: return 0xc73e8;
+		case iPad32_iOS931: return 0xc73e8;
 		case iPod51_iOS932: return 0xc73e8;
 		default: abort();
 	}
@@ -244,13 +253,14 @@ uint32_t find_vm_kernel_addrperm(void) {
 		case iPhone52_iOS932: return 0x45d978;
 		case iPhone53_iOS932: return 0x45d978;
 		case iPhone53_iOS933: return 0x45d978;
+		case iPad21_iOS931: return 0x455844;
 		case iPad21_iOS932: return 0x455844;
 		case iPad22_iOS932: return 0x455844;
 		case iPad23_iOS932: return 0x455844;
 		case iPad24_iOS932: return 0x455844;
 		case iPad23_iOS933: return 0x455844;
 		case iPad31_iOS934: return 0x455844;
-        case iPad32_iOS931: return 0x455844;
+		case iPad32_iOS931: return 0x455844;
 		case iPod51_iOS932: return 0x455844;
 		default: abort();
 	}
@@ -268,13 +278,14 @@ uint32_t find_kernel_pmap(void) {
 		case iPhone52_iOS932: return 0x3fe454;
 		case iPhone53_iOS932: return 0x3fe454;
 		case iPhone53_iOS933: return 0x3fe454;
+		case iPad21_iOS931: return 0x3f6454;
 		case iPad21_iOS932: return 0x3f6454;
 		case iPad22_iOS932: return 0x3f6454;
 		case iPad23_iOS932: return 0x3f6454;
 		case iPad24_iOS932: return 0x3f6454;
 		case iPad23_iOS933: return 0x3f6454;
 		case iPad31_iOS934: return 0x3f6454;
-        case iPad32_iOS931: return 0x3f6454;
+		case iPad32_iOS931: return 0x3f6454;
 		case iPod51_iOS932: return 0x3f6454;
 		default: abort();
 	}
@@ -292,13 +303,14 @@ uint32_t find_flush_dcache(void) {
 		case iPhone52_iOS932: return 0xbf274;
 		case iPhone53_iOS932: return 0xbf274;
 		case iPhone53_iOS933: return 0xbf404;
+		case iPad21_iOS931: return 0xbc250;
 		case iPad21_iOS932: return 0xbc260;
 		case iPad22_iOS932: return 0xbc260;
 		case iPad23_iOS932: return 0xbc260;
 		case iPad24_iOS932: return 0xbc260;
 		case iPad23_iOS933: return 0xbc1d8;
 		case iPad31_iOS934: return 0xbc1d4;
-        case iPad32_iOS931: return 0xbc250;
+		case iPad32_iOS931: return 0xbc250;
 		case iPod51_iOS932: return 0xbc260;
 		default: abort();
 	}
@@ -316,13 +328,14 @@ uint32_t find_invalidate_tlb(void) {
 		case iPhone52_iOS932: return 0xcb560;
 		case iPhone53_iOS932: return 0xcb560;
 		case iPhone53_iOS933: return 0xcb560;
+		case iPad21_iOS931: return 0xc7440;
 		case iPad21_iOS932: return 0xc7440;
 		case iPad22_iOS932: return 0xc7440;
 		case iPad23_iOS932: return 0xc7440;
 		case iPad24_iOS932: return 0xc7440;
 		case iPad23_iOS933: return 0xc7450;
 		case iPad31_iOS934: return 0xc7440;
-        case iPad32_iOS931: return 0xc7440;
+		case iPad32_iOS931: return 0xc7440;
 		case iPod51_iOS932: return 0xc7440;
 		default: abort();
 	}
@@ -340,13 +353,14 @@ uint32_t find_task_for_pid(void) {
 		case iPhone52_iOS932: return 0x302df0;
 		case iPhone53_iOS932: return 0x302df0;
 		case iPhone53_iOS933: return 0x302fd4;
+		case iPad21_iOS931: return 0x2fcc8c;
 		case iPad21_iOS932: return 0x2fcd80;
 		case iPad22_iOS932: return 0x2fcd80;
 		case iPad23_iOS932: return 0x2fcd80;
 		case iPad24_iOS932: return 0x2fcd80;
 		case iPad23_iOS933: return 0x2fcec0;
 		case iPad31_iOS934: return 0x2fcec0;
-        case iPad32_iOS931: return 0x2fcc8c;
+		case iPad32_iOS931: return 0x2fcc8c;
 		case iPod51_iOS932: return 0x2fcd80;
 		default: abort();
 	}
@@ -363,13 +377,14 @@ uint32_t find_setreuid(void) {
 		case iPhone52_iOS932: return 0x2af5f8;
 		case iPhone53_iOS932: return 0x2af5f8;
 		case iPhone53_iOS933: return 0x2af7b8;
+		case iPad21_iOS931: return 0x2a977c;
 		case iPad21_iOS932: return 0x2a985c;
 		case iPad22_iOS932: return 0x2a985c;
 		case iPad23_iOS932: return 0x2a985c;
 		case iPad24_iOS932: return 0x2a985c;
 		case iPad23_iOS933: return 0x2a9988;
 		case iPad31_iOS934: return 0x2a9988;
-        case iPad32_iOS931: return 0x2a977c;
+		case iPad32_iOS931: return 0x2a977c;
 		case iPod51_iOS932: return 0x2a985c;
 		default: abort();
 	}
@@ -386,13 +401,14 @@ uint32_t find_pid_check(void) {
 		case iPhone52_iOS932: return 0x16;
 		case iPhone53_iOS932: return 0x16;
 		case iPhone53_iOS933: return 0x16;
+		case iPad21_iOS931: return 0x14;
 		case iPad21_iOS932: return 0x14;
 		case iPad22_iOS932: return 0x14;
 		case iPad23_iOS932: return 0x14;
 		case iPad24_iOS932: return 0x14;
 		case iPad23_iOS933: return 0x14;
 		case iPad31_iOS934: return 0x14;
-        case iPad32_iOS931: return 0x14;
+		case iPad32_iOS931: return 0x14;
 		case iPod51_iOS932: return 0x14;
 		default: abort();
 	}
@@ -409,13 +425,14 @@ uint32_t find_posix_check(void) {
 		case iPhone52_iOS932: return 0x3e;
 		case iPhone53_iOS932: return 0x3e;
 		case iPhone53_iOS933: return 0x3e;
+		case iPad21_iOS931: return 0x3e;
 		case iPad21_iOS932: return 0x3e;
 		case iPad22_iOS932: return 0x3e;
 		case iPad23_iOS932: return 0x3e;
 		case iPad24_iOS932: return 0x3e;
 		case iPad23_iOS933: return 0x3e;
 		case iPad31_iOS934: return 0x3e;
-        case iPad32_iOS931: return 0x3e;
+		case iPad32_iOS931: return 0x3e;
 		case iPod51_iOS932: return 0x3e;
 		default: abort();
 	}
@@ -432,13 +449,14 @@ uint32_t find_mac_proc_check(void) {
 		case iPhone52_iOS932: return 0x1e6;
 		case iPhone53_iOS932: return 0x1e6;
 		case iPhone53_iOS933: return 0x1e6;
+		case iPad21_iOS931: return 0x1e6;
 		case iPad21_iOS932: return 0x1e6;
 		case iPad22_iOS932: return 0x1e6;
 		case iPad23_iOS932: return 0x1e6;
 		case iPad24_iOS932: return 0x1e6;
 		case iPad23_iOS933: return 0x1e6;
 		case iPad31_iOS934: return 0x1e6;
-        case iPad32_iOS931: return 0x1e6;
+		case iPad32_iOS931: return 0x1e6;
 		case iPod51_iOS932: return 0x1e6;
 		default: abort();
 	}

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -23,13 +23,14 @@ typedef enum {
 	iPhone52_iOS932,
 	iPhone53_iOS932,
 	iPhone53_iOS933,
+	iPad21_iOS931,
 	iPad21_iOS932,
 	iPad22_iOS932,
 	iPad23_iOS932,
 	iPad24_iOS932,
 	iPad23_iOS933,
 	iPad31_iOS934,
-    iPad32_iOS931,
+	iPad32_iOS931,
 	iPod51_iOS932
 } t_target_environment;
 


### PR DESCRIPTION
Xcode seems to have added spaces instead of tabs, let me know if you want this changing.

I tested these offsets on my iPad2,1 running iOS 9.3.1.