### PR TITLE
Add support for iPad2,1 iOS 9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Supported devices:
 * iPhone5,2 (N42AP), iOS 9.3.2 (Frisco 13F69)
 * iPhone5,3 (N48AP), iOS 9.3.2 (Frisco 13F69)
 * iPhone5,3 (N48AP), iOS 9.3.3 (Genoa 13G34)
+* iPad2,1 (K39AP), iOS 9.2 (Castlerock 13C75)
 * iPad2,1 (K93AP), iOS 9.3.1 (Eagle 13E238)
 * iPad2,1 (K93AP), iOS 9.3.2 (Frisco 13F69)
 * iPad2,1 (K93AP), iOS 9.3.3 (Genoa 13G34)

--- a/Trident/exploit.c
+++ b/Trident/exploit.c
@@ -197,7 +197,7 @@ uint32_t leak_kernel_base(void) {
         }
         printf("\n");
         
-        return *(uint32_t *)(data+36) & 0xFFF00000 + 0x1000;
+        return (*(uint32_t *)(data+36) & 0xFFF00000) + 0x1000;
     }
     return 0;
 }

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -26,7 +26,7 @@ t_target_environment info_to_target_environment(const char *device_model, const 
 	determineTarget("iPhone5,2", "9.3.2", iPhone52_iOS932);
 	determineTarget("iPhone5,3", "9.3.2", iPhone53_iOS932);
 	determineTarget("iPhone5,3", "9.3.3", iPhone53_iOS933);
-    determineTarget("iPad2,1", "9.2", iPad21_iOS920);
+    	determineTarget("iPad2,1", "9.2", iPad21_iOS920);
 	determineTarget("iPad2,1", "9.3", iPad21_iOS930);
 	determineTarget("iPad2,1", "9.3.1", iPad21_iOS931);
 	determineTarget("iPad2,1", "9.3.2", iPad21_iOS932);
@@ -61,7 +61,7 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPhone52_iOS932: return 0x31ef58;
 		case iPhone53_iOS932: return 0x31ef58;
 		case iPhone53_iOS933: return 0x31f13c;
-        case iPad21_iOS920: return 0x3106fc;
+        	case iPad21_iOS920: return 0x3106fc;
 		case iPad21_iOS930: return 0x31812c;
 		case iPad21_iOS931: return 0x31812c;
 		case iPad21_iOS932: return 0x318264;
@@ -93,7 +93,7 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 		case iPhone52_iOS932: return 0x322818;
 		case iPhone53_iOS932: return 0x322818;
 		case iPhone53_iOS933: return 0x3219fc;
-        case iPad21_iOS920: return 0x312e18;
+        	case iPad21_iOS920: return 0x312e18;
 		case iPad21_iOS930: return 0x31a934;
 		case iPad21_iOS931: return 0x31a934;
 		case iPad21_iOS932: return 0x31aa6c;
@@ -125,7 +125,7 @@ uint32_t find_calend_gettime(void) {
 		case iPhone52_iOS932: return 0x1e170;
 		case iPhone53_iOS932: return 0x1e170;
 		case iPhone53_iOS933: return 0x1eeac;
-        case iPad21_iOS920: return 0x1de84;
+        	case iPad21_iOS920: return 0x1de84;
 		case iPad21_iOS930: return 0x1e170;
 		case iPad21_iOS931: return 0x1e170;
 		case iPad21_iOS932: return 0x1e170;
@@ -157,7 +157,7 @@ uint32_t find_bufattr_cpx(void) {
 		case iPhone52_iOS932: return 0xdee6c;
 		case iPhone53_iOS932: return 0xdee6c;
 		case iPhone53_iOS933: return 0xdea48;
-        case iPad21_iOS920: return 0xd8750;
+        	case iPad21_iOS920: return 0xd8750;
 		case iPad21_iOS930: return 0xd9848;
 		case iPad21_iOS931: return 0xd9848;
 		case iPad21_iOS932: return 0xd9848;
@@ -189,7 +189,7 @@ uint32_t find_clock_ops(void) {
 		case iPhone52_iOS932: return 0x40b428;
 		case iPhone53_iOS932: return 0x40b428;
 		case iPhone53_iOS933: return 0x40b428;
-        case iPad21_iOS920: return 0x3fc3dc;
+        	case iPad21_iOS920: return 0x3fc3dc;
 		case iPad21_iOS930: return 0x403428;
 		case iPad21_iOS931: return 0x403428;
 		case iPad21_iOS932: return 0x403428;
@@ -221,7 +221,7 @@ uint32_t find_copyin(void) {
 		case iPhone52_iOS932: return 0xcb7dc;
 		case iPhone53_iOS932: return 0xcb7dc;
 		case iPhone53_iOS933: return 0xcb7dc;
-        case iPad21_iOS920: return 0xc6754;
+        	case iPad21_iOS920: return 0xc6754;
 		case iPad21_iOS930: return 0xc76b4;
 		case iPad21_iOS931: return 0xc76b4;
 		case iPad21_iOS932: return 0xc76b4;
@@ -253,7 +253,7 @@ uint32_t find_bx_lr(void) {
 		case iPhone52_iOS932: return 0xdea4a;
 		case iPhone53_iOS932: return 0xdea4a;
 		case iPhone53_iOS933: return 0xdea4a;
-        case iPad21_iOS920: return 0xd8752;
+        	case iPad21_iOS920: return 0xd8752;
 		case iPad21_iOS930: return 0xd984a;
 		case iPad21_iOS931: return 0xd984a;
 		case iPad21_iOS932: return 0xd984a;
@@ -285,7 +285,7 @@ uint32_t find_write_gadget(void) {
 		case iPhone52_iOS932: return 0xcb508;
 		case iPhone53_iOS932: return 0xcb508;
 		case iPhone53_iOS933: return 0xcb508;
-        case iPad21_iOS920: return 0xc6488;
+        	case iPad21_iOS920: return 0xc6488;
 		case iPad21_iOS930: return 0xc73e8;
 		case iPad21_iOS931: return 0xc73e8;
 		case iPad21_iOS932: return 0xc73e8;
@@ -316,7 +316,7 @@ uint32_t find_vm_kernel_addrperm(void) {
 		case iPhone52_iOS932: return 0x45d978;
 		case iPhone53_iOS932: return 0x45d978;
 		case iPhone53_iOS933: return 0x45d978;
-        case iPad21_iOS920: return 0x44e840;
+        	case iPad21_iOS920: return 0x44e840;
 		case iPad21_iOS930: return 0x455844;
 		case iPad21_iOS931: return 0x455844;
 		case iPad21_iOS932: return 0x455844;
@@ -348,7 +348,7 @@ uint32_t find_kernel_pmap(void) {
 		case iPhone52_iOS932: return 0x3fe454;
 		case iPhone53_iOS932: return 0x3fe454;
 		case iPhone53_iOS933: return 0x3fe454;
-        case iPad21_iOS920: return 0x3ef444;
+        	case iPad21_iOS920: return 0x3ef444;
 		case iPad21_iOS930: return 0x3f6454;
 		case iPad21_iOS931: return 0x3f6454;
 		case iPad21_iOS932: return 0x3f6454;
@@ -380,7 +380,7 @@ uint32_t find_flush_dcache(void) {
 		case iPhone52_iOS932: return 0xbf274;
 		case iPhone53_iOS932: return 0xbf274;
 		case iPhone53_iOS933: return 0xbf404;
-        case iPad21_iOS920: return 0xbb710;
+        	case iPad21_iOS920: return 0xbb710;
 		case iPad21_iOS930: return 0xbc250;
 		case iPad21_iOS931: return 0xbc250;
 		case iPad21_iOS932: return 0xbc260;
@@ -412,7 +412,7 @@ uint32_t find_invalidate_tlb(void) {
 		case iPhone52_iOS932: return 0xcb560;
 		case iPhone53_iOS932: return 0xcb560;
 		case iPhone53_iOS933: return 0xcb560;
-        case iPad21_iOS920: return 0xc64e0;
+        	case iPad21_iOS920: return 0xc64e0;
 		case iPad21_iOS930: return 0xc7440;
 		case iPad21_iOS931: return 0xc7440;
 		case iPad21_iOS932: return 0xc7440;
@@ -444,7 +444,7 @@ uint32_t find_task_for_pid(void) {
 		case iPhone52_iOS932: return 0x302df0;
 		case iPhone53_iOS932: return 0x302df0;
 		case iPhone53_iOS933: return 0x302fd4;
-        case iPad21_iOS920: return 0x2f55b4;
+        	case iPad21_iOS920: return 0x2f55b4;
 		case iPad21_iOS930: return 0x2fcc8c;
 		case iPad21_iOS931: return 0x2fcc8c;
 		case iPad21_iOS932: return 0x2fcd80;
@@ -475,7 +475,7 @@ uint32_t find_setreuid(void) {
 		case iPhone52_iOS932: return 0x2af5f8;
 		case iPhone53_iOS932: return 0x2af5f8;
 		case iPhone53_iOS933: return 0x2af7b8;
-        case iPad21_iOS920: return 0x2a3ab4;
+        	case iPad21_iOS920: return 0x2a3ab4;
 		case iPad21_iOS930: return 0x2a977c;
 		case iPad21_iOS931: return 0x2a977c;
 		case iPad21_iOS932: return 0x2a985c;
@@ -506,7 +506,7 @@ uint32_t find_pid_check(void) {
 		case iPhone52_iOS932: return 0x16;
 		case iPhone53_iOS932: return 0x16;
 		case iPhone53_iOS933: return 0x16;
-        case iPad21_iOS920: return 0x14;
+        	case iPad21_iOS920: return 0x14;
 		case iPad21_iOS930: return 0x14;
 		case iPad21_iOS931: return 0x14;
 		case iPad21_iOS932: return 0x14;
@@ -537,7 +537,7 @@ uint32_t find_posix_check(void) {
 		case iPhone52_iOS932: return 0x3e;
 		case iPhone53_iOS932: return 0x3e;
 		case iPhone53_iOS933: return 0x3e;
-        case iPad21_iOS920: return 0x3e;
+        	case iPad21_iOS920: return 0x3e;
 		case iPad21_iOS930: return 0x3e;
 		case iPad21_iOS931: return 0x3e;
 		case iPad21_iOS932: return 0x3e;
@@ -568,7 +568,7 @@ uint32_t find_mac_proc_check(void) {
 		case iPhone52_iOS932: return 0x1e6;
 		case iPhone53_iOS932: return 0x1e6;
 		case iPhone53_iOS933: return 0x1e6;
-        case iPad21_iOS920: return 0x1e6;
+        	case iPad21_iOS920: return 0x1e6;
 		case iPad21_iOS930: return 0x1e6;
 		case iPad21_iOS931: return 0x1e6;
 		case iPad21_iOS932: return 0x1e6;

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -26,6 +26,7 @@ t_target_environment info_to_target_environment(const char *device_model, const 
 	determineTarget("iPhone5,2", "9.3.2", iPhone52_iOS932);
 	determineTarget("iPhone5,3", "9.3.2", iPhone53_iOS932);
 	determineTarget("iPhone5,3", "9.3.3", iPhone53_iOS933);
+    determineTarget("iPad2,1", "9.2", iPad21_iOS920);
 	determineTarget("iPad2,1", "9.3", iPad21_iOS930);
 	determineTarget("iPad2,1", "9.3.1", iPad21_iOS931);
 	determineTarget("iPad2,1", "9.3.2", iPad21_iOS932);
@@ -60,6 +61,7 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPhone52_iOS932: return 0x31ef58;
 		case iPhone53_iOS932: return 0x31ef58;
 		case iPhone53_iOS933: return 0x31f13c;
+        case iPad21_iOS920: return 0x3106fc;
 		case iPad21_iOS930: return 0x31812c;
 		case iPad21_iOS931: return 0x31812c;
 		case iPad21_iOS932: return 0x318264;
@@ -91,6 +93,7 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 		case iPhone52_iOS932: return 0x322818;
 		case iPhone53_iOS932: return 0x322818;
 		case iPhone53_iOS933: return 0x3219fc;
+        case iPad21_iOS920: return 0x312e18;
 		case iPad21_iOS930: return 0x31a934;
 		case iPad21_iOS931: return 0x31a934;
 		case iPad21_iOS932: return 0x31aa6c;
@@ -122,6 +125,7 @@ uint32_t find_calend_gettime(void) {
 		case iPhone52_iOS932: return 0x1e170;
 		case iPhone53_iOS932: return 0x1e170;
 		case iPhone53_iOS933: return 0x1eeac;
+        case iPad21_iOS920: return 0x1de84;
 		case iPad21_iOS930: return 0x1e170;
 		case iPad21_iOS931: return 0x1e170;
 		case iPad21_iOS932: return 0x1e170;
@@ -153,6 +157,7 @@ uint32_t find_bufattr_cpx(void) {
 		case iPhone52_iOS932: return 0xdee6c;
 		case iPhone53_iOS932: return 0xdee6c;
 		case iPhone53_iOS933: return 0xdea48;
+        case iPad21_iOS920: return 0xd8750;
 		case iPad21_iOS930: return 0xd9848;
 		case iPad21_iOS931: return 0xd9848;
 		case iPad21_iOS932: return 0xd9848;
@@ -184,6 +189,7 @@ uint32_t find_clock_ops(void) {
 		case iPhone52_iOS932: return 0x40b428;
 		case iPhone53_iOS932: return 0x40b428;
 		case iPhone53_iOS933: return 0x40b428;
+        case iPad21_iOS920: return 0x3fc3dc;
 		case iPad21_iOS930: return 0x403428;
 		case iPad21_iOS931: return 0x403428;
 		case iPad21_iOS932: return 0x403428;
@@ -215,6 +221,7 @@ uint32_t find_copyin(void) {
 		case iPhone52_iOS932: return 0xcb7dc;
 		case iPhone53_iOS932: return 0xcb7dc;
 		case iPhone53_iOS933: return 0xcb7dc;
+        case iPad21_iOS920: return 0xc6754;
 		case iPad21_iOS930: return 0xc76b4;
 		case iPad21_iOS931: return 0xc76b4;
 		case iPad21_iOS932: return 0xc76b4;
@@ -246,6 +253,7 @@ uint32_t find_bx_lr(void) {
 		case iPhone52_iOS932: return 0xdea4a;
 		case iPhone53_iOS932: return 0xdea4a;
 		case iPhone53_iOS933: return 0xdea4a;
+        case iPad21_iOS920: return 0xd8752;
 		case iPad21_iOS930: return 0xd984a;
 		case iPad21_iOS931: return 0xd984a;
 		case iPad21_iOS932: return 0xd984a;
@@ -277,6 +285,7 @@ uint32_t find_write_gadget(void) {
 		case iPhone52_iOS932: return 0xcb508;
 		case iPhone53_iOS932: return 0xcb508;
 		case iPhone53_iOS933: return 0xcb508;
+        case iPad21_iOS920: return 0xc6488;
 		case iPad21_iOS930: return 0xc73e8;
 		case iPad21_iOS931: return 0xc73e8;
 		case iPad21_iOS932: return 0xc73e8;
@@ -307,6 +316,7 @@ uint32_t find_vm_kernel_addrperm(void) {
 		case iPhone52_iOS932: return 0x45d978;
 		case iPhone53_iOS932: return 0x45d978;
 		case iPhone53_iOS933: return 0x45d978;
+        case iPad21_iOS920: return 0x44e840;
 		case iPad21_iOS930: return 0x455844;
 		case iPad21_iOS931: return 0x455844;
 		case iPad21_iOS932: return 0x455844;
@@ -338,6 +348,7 @@ uint32_t find_kernel_pmap(void) {
 		case iPhone52_iOS932: return 0x3fe454;
 		case iPhone53_iOS932: return 0x3fe454;
 		case iPhone53_iOS933: return 0x3fe454;
+        case iPad21_iOS920: return 0x3ef444;
 		case iPad21_iOS930: return 0x3f6454;
 		case iPad21_iOS931: return 0x3f6454;
 		case iPad21_iOS932: return 0x3f6454;
@@ -369,6 +380,7 @@ uint32_t find_flush_dcache(void) {
 		case iPhone52_iOS932: return 0xbf274;
 		case iPhone53_iOS932: return 0xbf274;
 		case iPhone53_iOS933: return 0xbf404;
+        case iPad21_iOS920: return 0xbb710;
 		case iPad21_iOS930: return 0xbc250;
 		case iPad21_iOS931: return 0xbc250;
 		case iPad21_iOS932: return 0xbc260;
@@ -400,6 +412,7 @@ uint32_t find_invalidate_tlb(void) {
 		case iPhone52_iOS932: return 0xcb560;
 		case iPhone53_iOS932: return 0xcb560;
 		case iPhone53_iOS933: return 0xcb560;
+        case iPad21_iOS920: return 0xc64e0;
 		case iPad21_iOS930: return 0xc7440;
 		case iPad21_iOS931: return 0xc7440;
 		case iPad21_iOS932: return 0xc7440;
@@ -431,6 +444,7 @@ uint32_t find_task_for_pid(void) {
 		case iPhone52_iOS932: return 0x302df0;
 		case iPhone53_iOS932: return 0x302df0;
 		case iPhone53_iOS933: return 0x302fd4;
+        case iPad21_iOS920: return 0x2f55b4;
 		case iPad21_iOS930: return 0x2fcc8c;
 		case iPad21_iOS931: return 0x2fcc8c;
 		case iPad21_iOS932: return 0x2fcd80;
@@ -461,6 +475,7 @@ uint32_t find_setreuid(void) {
 		case iPhone52_iOS932: return 0x2af5f8;
 		case iPhone53_iOS932: return 0x2af5f8;
 		case iPhone53_iOS933: return 0x2af7b8;
+        case iPad21_iOS920: return 0x2a3ab4;
 		case iPad21_iOS930: return 0x2a977c;
 		case iPad21_iOS931: return 0x2a977c;
 		case iPad21_iOS932: return 0x2a985c;
@@ -491,6 +506,7 @@ uint32_t find_pid_check(void) {
 		case iPhone52_iOS932: return 0x16;
 		case iPhone53_iOS932: return 0x16;
 		case iPhone53_iOS933: return 0x16;
+        case iPad21_iOS920: return 0x14;
 		case iPad21_iOS930: return 0x14;
 		case iPad21_iOS931: return 0x14;
 		case iPad21_iOS932: return 0x14;
@@ -521,6 +537,7 @@ uint32_t find_posix_check(void) {
 		case iPhone52_iOS932: return 0x3e;
 		case iPhone53_iOS932: return 0x3e;
 		case iPhone53_iOS933: return 0x3e;
+        case iPad21_iOS920: return 0x3e;
 		case iPad21_iOS930: return 0x3e;
 		case iPad21_iOS931: return 0x3e;
 		case iPad21_iOS932: return 0x3e;
@@ -551,6 +568,7 @@ uint32_t find_mac_proc_check(void) {
 		case iPhone52_iOS932: return 0x1e6;
 		case iPhone53_iOS932: return 0x1e6;
 		case iPhone53_iOS933: return 0x1e6;
+        case iPad21_iOS920: return 0x1e6;
 		case iPad21_iOS930: return 0x1e6;
 		case iPad21_iOS931: return 0x1e6;
 		case iPad21_iOS932: return 0x1e6;

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -24,7 +24,7 @@ typedef enum {
 	iPhone52_iOS932,
 	iPhone53_iOS932,
 	iPhone53_iOS933,
-    iPad21_iOS920,
+    	iPad21_iOS920,
 	iPad21_iOS930,
 	iPad21_iOS931,
 	iPad21_iOS932,

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -24,6 +24,7 @@ typedef enum {
 	iPhone52_iOS932,
 	iPhone53_iOS932,
 	iPhone53_iOS933,
+    iPad21_iOS920,
 	iPad21_iOS930,
 	iPad21_iOS931,
 	iPad21_iOS932,


### PR DESCRIPTION
This pull request adds support for iPad2,1 iOS9.2
A lot of credit goes to @hazytint for fixing the 9.2 memory leak :D