### PR TITLE
Add support for iPhone5,3 on iOS 9.2.1 and fix order of device combinations

### DIFF
--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -26,6 +26,7 @@ t_target_environment info_to_target_environment(const char *device_model, const 
 	determineTarget("iPhone5,2", "9.2", iPhone52_iOS920);
 	determineTarget("iPhone5,2", "9.2.1", iPhone52_iOS921);
 	determineTarget("iPhone5,2", "9.3.2", iPhone52_iOS932);
+	determineTarget("iPhone5,3", "9.2.1", iPhone53_iOS921);
 	determineTarget("iPhone5,3", "9.3.2", iPhone53_iOS932);
 	determineTarget("iPhone5,3", "9.3.3", iPhone53_iOS933);
     	determineTarget("iPad2,1", "9.2", iPad21_iOS920);
@@ -64,6 +65,7 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPhone52_iOS920: return 0x317768;
 		case iPhone52_iOS921: return 0x317868;
 		case iPhone52_iOS932: return 0x31ef58;
+		case iPhone53_iOS921: return 0x317868;
 		case iPhone53_iOS932: return 0x31ef58;
 		case iPhone53_iOS933: return 0x31f13c;
         	case iPad21_iOS920: return 0x3106fc;
@@ -99,6 +101,7 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 		case iPhone52_iOS920: return 0x319ea0;
 		case iPhone52_iOS921: return 0x319fa0;
 		case iPhone52_iOS932: return 0x322818;
+		case iPhone53_iOS921: return 0x3176e4;
 		case iPhone53_iOS932: return 0x322818;
 		case iPhone53_iOS933: return 0x3219fc;
         	case iPad21_iOS920: return 0x312e18;
@@ -134,6 +137,7 @@ uint32_t find_calend_gettime(void) {
 		case iPhone52_iOS920: return 0x1ebac;
 		case iPhone52_iOS921: return 0x1eb88;
 		case iPhone52_iOS932: return 0x1e170;
+		case iPhone53_iOS921: return 0x1eb88;
 		case iPhone53_iOS932: return 0x1e170;
 		case iPhone53_iOS933: return 0x1eeac;
         	case iPad21_iOS920: return 0x1de84;
@@ -169,6 +173,7 @@ uint32_t find_bufattr_cpx(void) {
 		case iPhone52_iOS920: return 0xdd9dc;
 		case iPhone52_iOS921: return 0xdd9dc;
 		case iPhone52_iOS932: return 0xdee6c;
+		case iPhone53_iOS921: return 0xdd9dc;
 		case iPhone53_iOS932: return 0xdee6c;
 		case iPhone53_iOS933: return 0xdea48;
         	case iPad21_iOS920: return 0xd8750;
@@ -204,6 +209,7 @@ uint32_t find_clock_ops(void) {
 		case iPhone52_iOS920: return 0x4033dc;
 		case iPhone52_iOS921: return 0x4033dc;
 		case iPhone52_iOS932: return 0x40b428;
+		case iPhone53_iOS921: return 0x4033dc;
 		case iPhone53_iOS932: return 0x40b428;
 		case iPhone53_iOS933: return 0x40b428;
         	case iPad21_iOS920: return 0x3fc3dc;
@@ -239,6 +245,7 @@ uint32_t find_copyin(void) {
 		case iPhone52_iOS920: return 0xca87c;
 		case iPhone52_iOS921: return 0xca87c;
 		case iPhone52_iOS932: return 0xcb7dc;
+		case iPhone53_iOS921: return 0xca87c;
 		case iPhone53_iOS932: return 0xcb7dc;
 		case iPhone53_iOS933: return 0xcb7dc;
         	case iPad21_iOS920: return 0xc6754;
@@ -274,6 +281,7 @@ uint32_t find_bx_lr(void) {
 		case iPhone52_iOS920: return 0xdd9de;
 		case iPhone52_iOS921: return 0xdd9de;
 		case iPhone52_iOS932: return 0xdea4a;
+		case iPhone53_iOS921: return 0xdd9de;
 		case iPhone53_iOS932: return 0xdea4a;
 		case iPhone53_iOS933: return 0xdea4a;
         	case iPad21_iOS920: return 0xd8752;
@@ -309,6 +317,7 @@ uint32_t find_write_gadget(void) {
 		case iPhone52_iOS920: return 0xca5a8;
 		case iPhone52_iOS921: return 0xca5a8;
 		case iPhone52_iOS932: return 0xcb508;
+		case iPhone53_iOS921: return 0xca5a8;
 		case iPhone53_iOS932: return 0xcb508;
 		case iPhone53_iOS933: return 0xcb508;
         	case iPad21_iOS920: return 0xc6488;
@@ -343,6 +352,7 @@ uint32_t find_vm_kernel_addrperm(void) {
 		case iPhone52_iOS920: return 0x455964;
 		case iPhone52_iOS921: return 0x455964;
 		case iPhone52_iOS932: return 0x45d978;
+		case iPhone53_iOS921: return 0x455964;
 		case iPhone53_iOS932: return 0x45d978;
 		case iPhone53_iOS933: return 0x45d978;
         	case iPad21_iOS920: return 0x44e840;
@@ -378,6 +388,7 @@ uint32_t find_kernel_pmap(void) {
 		case iPhone52_iOS920: return 0x3f6444;
 		case iPhone52_iOS921: return 0x3f6444;
 		case iPhone52_iOS932: return 0x3fe454;
+		case iPhone53_iOS921: return 0x3f6444;
 		case iPhone53_iOS932: return 0x3fe454;
 		case iPhone53_iOS933: return 0x3fe454;
         	case iPad21_iOS920: return 0x3ef444;
@@ -413,6 +424,7 @@ uint32_t find_flush_dcache(void) {
 		case iPhone52_iOS920: return 0xbe5d0;
 		case iPhone52_iOS921: return 0xbe610;
 		case iPhone52_iOS932: return 0xbf274;
+		case iPhone53_iOS921: return 0xbe610;
 		case iPhone53_iOS932: return 0xbf274;
 		case iPhone53_iOS933: return 0xbf404;
         	case iPad21_iOS920: return 0xbb710;
@@ -448,6 +460,7 @@ uint32_t find_invalidate_tlb(void) {
 		case iPhone52_iOS920: return 0xca600;
 		case iPhone52_iOS921: return 0xca600;
 		case iPhone52_iOS932: return 0xcb560;
+		case iPhone53_iOS921: return 0xca600;
 		case iPhone53_iOS932: return 0xcb560;
 		case iPhone53_iOS933: return 0xcb560;
         	case iPad21_iOS920: return 0xc64e0;
@@ -483,6 +496,7 @@ uint32_t find_task_for_pid(void) {
 		case iPhone52_iOS920: return 0x2fbb8c;
 		case iPhone52_iOS921: return 0x2fbc9c;
 		case iPhone52_iOS932: return 0x302df0;
+		case iPhone53_iOS921: return 0x2fbc9c;
 		case iPhone53_iOS932: return 0x302df0;
 		case iPhone53_iOS933: return 0x302fd4;
         	case iPad21_iOS920: return 0x2f55b4;
@@ -515,6 +529,7 @@ uint32_t find_setreuid(void) {
 		case iPhone41_iOS933: return 0x2a9988;
 		case iPhone41_iOS934: return 0x2a9988;
 		case iPhone52_iOS932: return 0x2af5f8;
+		case iPhone53_iOS921: return 0x2a9f34;
 		case iPhone53_iOS932: return 0x2af5f8;
 		case iPhone53_iOS933: return 0x2af7b8;
         	case iPad21_iOS920: return 0x2a3ab4;
@@ -549,6 +564,7 @@ uint32_t find_pid_check(void) {
 		case iPhone52_iOS920: return 0x16;
 		case iPhone52_iOS921: return 0x16;
 		case iPhone52_iOS932: return 0x16;
+		case iPhone53_iOS921: return 0x16;
 		case iPhone53_iOS932: return 0x16;
 		case iPhone53_iOS933: return 0x16;
         	case iPad21_iOS920: return 0x14;
@@ -583,6 +599,7 @@ uint32_t find_posix_check(void) {
 		case iPhone52_iOS920: return 0x3e;
 		case iPhone52_iOS921: return 0x3e;
 		case iPhone52_iOS932: return 0x3e;
+		case iPhone53_iOS921: return 0x3e;
 		case iPhone53_iOS932: return 0x3e;
 		case iPhone53_iOS933: return 0x3e;
         	case iPad21_iOS920: return 0x3e;
@@ -617,6 +634,7 @@ uint32_t find_mac_proc_check(void) {
 		case iPhone52_iOS920: return 0x1e6;
 		case iPhone52_iOS921: return 0x1e6;
 		case iPhone52_iOS932: return 0x1e6;
+		case iPhone53_iOS921: return 0x1e6;
 		case iPhone53_iOS932: return 0x1e6;
 		case iPhone53_iOS933: return 0x1e6;
         	case iPad21_iOS920: return 0x1e6;

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -16,7 +16,6 @@
 t_target_environment target_environment = NotSupported;
 
 t_target_environment info_to_target_environment(const char *device_model, const char *system_version) {
-	determineTarget("iPhone5,2", "9.2.1", iPhone52_iOS921);
 	determineTarget("iPhone4,1", "9.3", iPhone41_iOS930);
 	determineTarget("iPhone4,1", "9.2.1", iPhone41_iOS921);
 	determineTarget("iPhone4,1", "9.3.1", iPhone41_iOS931);
@@ -24,6 +23,8 @@ t_target_environment info_to_target_environment(const char *device_model, const 
 	determineTarget("iPhone4,1", "9.3.3", iPhone41_iOS933);
 	determineTarget("iPhone4,1", "9.3.4", iPhone41_iOS934);
 	determineTarget("iPhone5,1", "9.3.2", iPhone51_iOS932);
+	determineTarget("iPhone5,2", "9.2", iPhone52_iOS920);
+	determineTarget("iPhone5,2", "9.2.1", iPhone52_iOS921);
 	determineTarget("iPhone5,2", "9.3.2", iPhone52_iOS932);
 	determineTarget("iPhone5,3", "9.3.2", iPhone53_iOS932);
 	determineTarget("iPhone5,3", "9.3.3", iPhone53_iOS933);
@@ -38,8 +39,8 @@ t_target_environment info_to_target_environment(const char *device_model, const 
 	determineTarget("iPad2,2", "9.3.2", iPad22_iOS932);
 	determineTarget("iPad2,2", "9.3.3", iPad22_iOS933);
 	determineTarget("iPad2,3", "9.3.2", iPad23_iOS932);
-	determineTarget("iPad2,4", "9.3.2", iPad24_iOS932);
 	determineTarget("iPad2,3", "9.3.3", iPad23_iOS933);
+	determineTarget("iPad2,4", "9.3.2", iPad24_iOS932);
 	determineTarget("iPad3,1", "9.3.4", iPad31_iOS934);
 	determineTarget("iPad3,2", "9.3.1", iPad32_iOS931);
 	determineTarget("iPad3,3", "9.3.3", iPad33_iOS933);
@@ -53,8 +54,6 @@ void init_target_environment(const char *device_model, const char *system_versio
 
 uint32_t find_OSSerializer_serialize(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x317768;
-		case iPhone52_iOS921: return 0x317868;
 		case iPhone41_iOS921: return 0x3107fc;
 		case iPhone41_iOS930: return 0x31812c;
 		case iPhone41_iOS931: return 0x31812c;
@@ -62,6 +61,8 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPhone41_iOS933: return 0x318388;
 		case iPhone41_iOS934: return 0x318388;
 		case iPhone51_iOS932: return 0x31ef46;
+		case iPhone52_iOS920: return 0x317768;
+		case iPhone52_iOS921: return 0x317868;
 		case iPhone52_iOS932: return 0x31ef58;
 		case iPhone53_iOS932: return 0x31ef58;
 		case iPhone53_iOS933: return 0x31f13c;
@@ -76,8 +77,8 @@ uint32_t find_OSSerializer_serialize(void) {
 		case iPad22_iOS932: return 0x318264;
 		case iPad22_iOS933: return 0x318388;
 		case iPad23_iOS932: return 0x318264;
-		case iPad24_iOS932: return 0x318264;
 		case iPad23_iOS933: return 0x318388;
+		case iPad24_iOS932: return 0x318264;
 		case iPad31_iOS934: return 0x318388;
 		case iPad32_iOS931: return 0x31812c;
 		case iPad33_iOS933: return 0x318388;
@@ -88,8 +89,6 @@ uint32_t find_OSSerializer_serialize(void) {
 
 uint32_t find_OSSymbol_getMetaClass(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x319ea0;
-		case iPhone52_iOS921: return 0x319fa0;
 		case iPhone41_iOS921: return 0x312f18;
 		case iPhone41_iOS930: return 0x31a934;
 		case iPhone41_iOS931: return 0x31a934;
@@ -97,6 +96,8 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 		case iPhone41_iOS933: return 0x31ab90;
 		case iPhone41_iOS934: return 0x31ab90;
 		case iPhone51_iOS932: return 0x321818;
+		case iPhone52_iOS920: return 0x319ea0;
+		case iPhone52_iOS921: return 0x319fa0;
 		case iPhone52_iOS932: return 0x322818;
 		case iPhone53_iOS932: return 0x322818;
 		case iPhone53_iOS933: return 0x3219fc;
@@ -111,8 +112,8 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 		case iPad22_iOS932: return 0x31aa6c;
 		case iPad22_iOS933: return 0x31ab90;
 		case iPad23_iOS932: return 0x31aa6c;
-		case iPad24_iOS932: return 0x31aa6c;
 		case iPad23_iOS933: return 0x31ab90;
+		case iPad24_iOS932: return 0x31aa6c;
 		case iPad31_iOS934: return 0x31ab90;
 		case iPad32_iOS931: return 0x31a934;
 		case iPad33_iOS933: return 0x31ab90;
@@ -123,8 +124,6 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 
 uint32_t find_calend_gettime(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x1ebac;
-		case iPhone52_iOS921: return 0x1eb88;
 		case iPhone41_iOS921: return 0x1de60;
 		case iPhone41_iOS930: return 0x1e170;
 		case iPhone41_iOS931: return 0x1e170;
@@ -132,6 +131,8 @@ uint32_t find_calend_gettime(void) {
 		case iPhone41_iOS933: return 0x1e200;
 		case iPhone41_iOS934: return 0x1e200;
 		case iPhone51_iOS932: return 0x1ee6c;
+		case iPhone52_iOS920: return 0x1ebac;
+		case iPhone52_iOS921: return 0x1eb88;
 		case iPhone52_iOS932: return 0x1e170;
 		case iPhone53_iOS932: return 0x1e170;
 		case iPhone53_iOS933: return 0x1eeac;
@@ -146,8 +147,8 @@ uint32_t find_calend_gettime(void) {
 		case iPad22_iOS932: return 0x1e170;
 		case iPad22_iOS933: return 0x1e200;
 		case iPad23_iOS932: return 0x1e170;
-		case iPad24_iOS932: return 0x1e170;
 		case iPad23_iOS933: return 0x1e200;
+		case iPad24_iOS932: return 0x1e170;
 		case iPad31_iOS934: return 0x1e200;
 		case iPad32_iOS931: return 0x1e170;
 		case iPad33_iOS933: return 0x1e200;
@@ -158,8 +159,6 @@ uint32_t find_calend_gettime(void) {
 
 uint32_t find_bufattr_cpx(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0xdd9dc;
-		case iPhone52_iOS921: return 0xdd9dc;
 		case iPhone41_iOS921: return 0xd8750;
 		case iPhone41_iOS930: return 0xd9848;
 		case iPhone41_iOS931: return 0xd9848;
@@ -167,6 +166,8 @@ uint32_t find_bufattr_cpx(void) {
 		case iPhone41_iOS933: return 0xd9838;
 		case iPhone41_iOS934: return 0xd9838;
 		case iPhone51_iOS932: return 0xdea48;
+		case iPhone52_iOS920: return 0xdd9dc;
+		case iPhone52_iOS921: return 0xdd9dc;
 		case iPhone52_iOS932: return 0xdee6c;
 		case iPhone53_iOS932: return 0xdee6c;
 		case iPhone53_iOS933: return 0xdea48;
@@ -181,8 +182,8 @@ uint32_t find_bufattr_cpx(void) {
 		case iPad22_iOS932: return 0xd9848;
 		case iPad22_iOS933: return 0xd9838;
 		case iPad23_iOS932: return 0xd9848;
-		case iPad24_iOS932: return 0xd9848;
 		case iPad23_iOS933: return 0xd9838;
+		case iPad24_iOS932: return 0xd9848;
 		case iPad31_iOS934: return 0xd9838;
 		case iPad32_iOS931: return 0xd9848;
 		case iPad33_iOS933: return 0xd9838;
@@ -193,8 +194,6 @@ uint32_t find_bufattr_cpx(void) {
 
 uint32_t find_clock_ops(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x4033dc;
-		case iPhone52_iOS921: return 0x4033dc;
 		case iPhone41_iOS921: return 0x3fc3dc;
 		case iPhone41_iOS930: return 0x403428;
 		case iPhone41_iOS931: return 0x403428;
@@ -202,6 +201,8 @@ uint32_t find_clock_ops(void) {
 		case iPhone41_iOS933: return 0x403428;
 		case iPhone41_iOS934: return 0x403428;
 		case iPhone51_iOS932: return 0x40b654;
+		case iPhone52_iOS920: return 0x4033dc;
+		case iPhone52_iOS921: return 0x4033dc;
 		case iPhone52_iOS932: return 0x40b428;
 		case iPhone53_iOS932: return 0x40b428;
 		case iPhone53_iOS933: return 0x40b428;
@@ -216,8 +217,8 @@ uint32_t find_clock_ops(void) {
 		case iPad22_iOS932: return 0x403428;
 		case iPad22_iOS933: return 0x403428;
 		case iPad23_iOS932: return 0x403428;
-		case iPad24_iOS932: return 0x403428;
 		case iPad23_iOS933: return 0x403428;
+		case iPad24_iOS932: return 0x403428;
 		case iPad31_iOS934: return 0x403428;
 		case iPad32_iOS931: return 0x403428;
 		case iPad33_iOS933: return 0x403428;
@@ -228,8 +229,6 @@ uint32_t find_clock_ops(void) {
 
 uint32_t find_copyin(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0xca87c;
-		case iPhone52_iOS921: return 0xca87c;
 		case iPhone41_iOS921: return 0xc6754;
 		case iPhone41_iOS930: return 0xc76b4;
 		case iPhone41_iOS931: return 0xc76b4;
@@ -237,6 +236,8 @@ uint32_t find_copyin(void) {
 		case iPhone41_iOS933: return 0xc76b4;
 		case iPhone41_iOS934: return 0xc76b4;
 		case iPhone51_iOS932: return 0xcb7dc;
+		case iPhone52_iOS920: return 0xca87c;
+		case iPhone52_iOS921: return 0xca87c;
 		case iPhone52_iOS932: return 0xcb7dc;
 		case iPhone53_iOS932: return 0xcb7dc;
 		case iPhone53_iOS933: return 0xcb7dc;
@@ -251,8 +252,8 @@ uint32_t find_copyin(void) {
 		case iPad22_iOS932: return 0xc76b4;
 		case iPad22_iOS933: return 0xc76b4;
 		case iPad23_iOS932: return 0xc76b4;
-		case iPad24_iOS932: return 0xc76b4;
 		case iPad23_iOS933: return 0xc76b4;
+		case iPad24_iOS932: return 0xc76b4;
 		case iPad31_iOS934: return 0xc76b4;
 		case iPad32_iOS931: return 0xc76b4;
 		case iPad33_iOS933: return 0xc76b4;
@@ -263,8 +264,6 @@ uint32_t find_copyin(void) {
 
 uint32_t find_bx_lr(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0xdd9de;
-		case iPhone52_iOS921: return 0xdd9de;
 		case iPhone41_iOS921: return 0xd8752;
 		case iPhone41_iOS930: return 0xd984a;
 		case iPhone41_iOS931: return 0xd984a;
@@ -272,6 +271,8 @@ uint32_t find_bx_lr(void) {
 		case iPhone41_iOS933: return 0xd983a;
 		case iPhone41_iOS934: return 0xd983a;
 		case iPhone51_iOS932: return 0xdea4a;
+		case iPhone52_iOS920: return 0xdd9de;
+		case iPhone52_iOS921: return 0xdd9de;
 		case iPhone52_iOS932: return 0xdea4a;
 		case iPhone53_iOS932: return 0xdea4a;
 		case iPhone53_iOS933: return 0xdea4a;
@@ -286,8 +287,8 @@ uint32_t find_bx_lr(void) {
 		case iPad22_iOS932: return 0xd984a;
 		case iPad22_iOS933: return 0xd983a;
 		case iPad23_iOS932: return 0xd984a;
-		case iPad24_iOS932: return 0xd984a;
 		case iPad23_iOS933: return 0xd983a;
+		case iPad24_iOS932: return 0xd984a;
 		case iPad31_iOS934: return 0xd983a;
 		case iPad32_iOS931: return 0xd984a;
 		case iPad33_iOS933: return 0xd983a;
@@ -298,8 +299,6 @@ uint32_t find_bx_lr(void) {
 
 uint32_t find_write_gadget(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0xca5a8;
-		case iPhone52_iOS921: return 0xca5a8;
 		case iPhone41_iOS921: return 0xc6488;
 		case iPhone41_iOS930: return 0xc73e8;
 		case iPhone41_iOS931: return 0xc73e8;
@@ -307,6 +306,8 @@ uint32_t find_write_gadget(void) {
 		case iPhone41_iOS933: return 0xc73e8;
 		case iPhone41_iOS934: return 0xc73e8;
 		case iPhone51_iOS932: return 0xcb508;
+		case iPhone52_iOS920: return 0xca5a8;
+		case iPhone52_iOS921: return 0xca5a8;
 		case iPhone52_iOS932: return 0xcb508;
 		case iPhone53_iOS932: return 0xcb508;
 		case iPhone53_iOS933: return 0xcb508;
@@ -321,8 +322,8 @@ uint32_t find_write_gadget(void) {
 		case iPad22_iOS932: return 0xc73e8;
 		case iPad22_iOS933: return 0xc73e8;
 		case iPad23_iOS932: return 0xc73e8;
-		case iPad24_iOS932: return 0xc73e8;
 		case iPad23_iOS933: return 0xc73e8;
+		case iPad24_iOS932: return 0xc73e8;
 		case iPad31_iOS934: return 0xc73e8;
 		case iPad32_iOS931: return 0xc73e8;
 		case iPad33_iOS933: return 0xc73e8;
@@ -333,14 +334,14 @@ uint32_t find_write_gadget(void) {
 
 uint32_t find_vm_kernel_addrperm(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x455964;
-		case iPhone52_iOS921: return 0x455964;
 		case iPhone41_iOS921: return 0x44e840;
 		case iPhone41_iOS930: return 0x455844;
 		case iPhone41_iOS931: return 0x455844;
 		case iPhone41_iOS932: return 0x455844;
 		case iPhone41_iOS933: return 0x455844;
 		case iPhone41_iOS934: return 0x455844;
+		case iPhone52_iOS920: return 0x455964;
+		case iPhone52_iOS921: return 0x455964;
 		case iPhone52_iOS932: return 0x45d978;
 		case iPhone53_iOS932: return 0x45d978;
 		case iPhone53_iOS933: return 0x45d978;
@@ -355,8 +356,8 @@ uint32_t find_vm_kernel_addrperm(void) {
 		case iPad22_iOS932: return 0x455844;
 		case iPad22_iOS933: return 0x455844;
 		case iPad23_iOS932: return 0x455844;
-		case iPad24_iOS932: return 0x455844;
 		case iPad23_iOS933: return 0x455844;
+		case iPad24_iOS932: return 0x455844;
 		case iPad31_iOS934: return 0x455844;
 		case iPad32_iOS931: return 0x455844;
 		case iPad33_iOS933: return 0x455844;
@@ -367,8 +368,6 @@ uint32_t find_vm_kernel_addrperm(void) {
 
 uint32_t find_kernel_pmap(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x3f6444;
-		case iPhone52_iOS921: return 0x3f6444;
 		case iPhone41_iOS921: return 0x3ef444;
 		case iPhone41_iOS930: return 0x3f6454;
 		case iPhone41_iOS931: return 0x3f6454;
@@ -376,6 +375,8 @@ uint32_t find_kernel_pmap(void) {
 		case iPhone41_iOS933: return 0x3f6454;
 		case iPhone41_iOS934: return 0x3f6454;
 		case iPhone51_iOS932: return 0x3fe454;
+		case iPhone52_iOS920: return 0x3f6444;
+		case iPhone52_iOS921: return 0x3f6444;
 		case iPhone52_iOS932: return 0x3fe454;
 		case iPhone53_iOS932: return 0x3fe454;
 		case iPhone53_iOS933: return 0x3fe454;
@@ -390,8 +391,8 @@ uint32_t find_kernel_pmap(void) {
 		case iPad22_iOS932: return 0x3f6454;
 		case iPad22_iOS933: return 0x3f6454;
 		case iPad23_iOS932: return 0x3f6454;
-		case iPad24_iOS932: return 0x3f6454;
 		case iPad23_iOS933: return 0x3f6454;
+		case iPad24_iOS932: return 0x3f6454;
 		case iPad31_iOS934: return 0x3f6454;
 		case iPad32_iOS931: return 0x3f6454;
 		case iPad33_iOS933: return 0x3f6454;
@@ -402,8 +403,6 @@ uint32_t find_kernel_pmap(void) {
 
 uint32_t find_flush_dcache(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0xbe5d0;
-		case iPhone52_iOS921: return 0xbe610;
 		case iPhone41_iOS921: return 0xbb760;
 		case iPhone41_iOS930: return 0xbc250;
 		case iPhone41_iOS931: return 0xbc250;
@@ -411,6 +410,8 @@ uint32_t find_flush_dcache(void) {
 		case iPhone41_iOS933: return 0xbc1d4;
 		case iPhone41_iOS934: return 0xbc1d4;
 		case iPhone51_iOS932: return 0xbf274;
+		case iPhone52_iOS920: return 0xbe5d0;
+		case iPhone52_iOS921: return 0xbe610;
 		case iPhone52_iOS932: return 0xbf274;
 		case iPhone53_iOS932: return 0xbf274;
 		case iPhone53_iOS933: return 0xbf404;
@@ -425,8 +426,8 @@ uint32_t find_flush_dcache(void) {
 		case iPad22_iOS932: return 0xbc260;
 		case iPad22_iOS933: return 0xbc1d4;
 		case iPad23_iOS932: return 0xbc260;
-		case iPad24_iOS932: return 0xbc260;
 		case iPad23_iOS933: return 0xbc1d8;
+		case iPad24_iOS932: return 0xbc260;
 		case iPad31_iOS934: return 0xbc1d4;
 		case iPad32_iOS931: return 0xbc250;
 		case iPad33_iOS933: return 0xbc1d4;
@@ -437,8 +438,6 @@ uint32_t find_flush_dcache(void) {
 
 uint32_t find_invalidate_tlb(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0xca600;
-		case iPhone52_iOS921: return 0xca600;
 		case iPhone41_iOS921: return 0xc64e0;
 		case iPhone41_iOS930: return 0xc7440;
 		case iPhone41_iOS931: return 0xc7440;
@@ -446,6 +445,8 @@ uint32_t find_invalidate_tlb(void) {
 		case iPhone41_iOS933: return 0xc7440;
 		case iPhone41_iOS934: return 0xc7440;
 		case iPhone51_iOS932: return 0xcb560;
+		case iPhone52_iOS920: return 0xca600;
+		case iPhone52_iOS921: return 0xca600;
 		case iPhone52_iOS932: return 0xcb560;
 		case iPhone53_iOS932: return 0xcb560;
 		case iPhone53_iOS933: return 0xcb560;
@@ -460,8 +461,8 @@ uint32_t find_invalidate_tlb(void) {
 		case iPad22_iOS932: return 0xc7440;
 		case iPad22_iOS933: return 0xc7440;
 		case iPad23_iOS932: return 0xc7440;
-		case iPad24_iOS932: return 0xc7440;
 		case iPad23_iOS933: return 0xc7450;
+		case iPad24_iOS932: return 0xc7440;
 		case iPad31_iOS934: return 0xc7440;
 		case iPad32_iOS931: return 0xc7440;
 		case iPad33_iOS933: return 0xc7440;
@@ -472,8 +473,6 @@ uint32_t find_invalidate_tlb(void) {
 
 uint32_t find_task_for_pid(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x2fbb8c;
-		case iPhone52_iOS921: return 0x2fbc9c;
 		case iPhone41_iOS921: return 0x2f56c4;
 		case iPhone41_iOS930: return 0x2fcc8c;
 		case iPhone41_iOS931: return 0x2fcc8c;
@@ -481,6 +480,8 @@ uint32_t find_task_for_pid(void) {
 		case iPhone41_iOS933: return 0x2fcec0;
 		case iPhone41_iOS934: return 0x2fcec0;
 		case iPhone51_iOS932: return 0x302df0;
+		case iPhone52_iOS920: return 0x2fbb8c;
+		case iPhone52_iOS921: return 0x2fbc9c;
 		case iPhone52_iOS932: return 0x302df0;
 		case iPhone53_iOS932: return 0x302df0;
 		case iPhone53_iOS933: return 0x302fd4;
@@ -495,8 +496,8 @@ uint32_t find_task_for_pid(void) {
 		case iPad22_iOS932: return 0x2fcd80;
 		case iPad22_iOS933: return 0x2fcec0;
 		case iPad23_iOS932: return 0x2fcd80;
-		case iPad24_iOS932: return 0x2fcd80;
 		case iPad23_iOS933: return 0x2fcec0;
+		case iPad24_iOS932: return 0x2fcd80;
 		case iPad31_iOS934: return 0x2fcec0;
 		case iPad32_iOS931: return 0x2fcc8c;
 		case iPad33_iOS933: return 0x2fcec0;
@@ -507,8 +508,6 @@ uint32_t find_task_for_pid(void) {
 
 uint32_t find_setreuid(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x2a9e24;
-		case iPhone52_iOS921: return 0x2a9f34;
 		case iPhone41_iOS921: return 0x2a3bc4;
 		case iPhone41_iOS930: return 0x2a977c;
 		case iPhone41_iOS931: return 0x2a977c;
@@ -529,8 +528,8 @@ uint32_t find_setreuid(void) {
 		case iPad22_iOS932: return 0x2a985c;
 		case iPad22_iOS933: return 0x2a9988;
 		case iPad23_iOS932: return 0x2a985c;
-		case iPad24_iOS932: return 0x2a985c;
 		case iPad23_iOS933: return 0x2a9988;
+		case iPad24_iOS932: return 0x2a985c;
 		case iPad31_iOS934: return 0x2a9988;
 		case iPad32_iOS931: return 0x2a977c;
 		case iPad33_iOS933: return 0x2a9988;
@@ -541,14 +540,14 @@ uint32_t find_setreuid(void) {
 
 uint32_t find_pid_check(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x16;
-		case iPhone52_iOS921: return 0x16;
 		case iPhone41_iOS921: return 0x14;
 		case iPhone41_iOS930: return 0x14;
 		case iPhone41_iOS931: return 0x14;
 		case iPhone41_iOS932: return 0x14;
 		case iPhone41_iOS933: return 0x14;
 		case iPhone41_iOS934: return 0x14;
+		case iPhone52_iOS920: return 0x16;
+		case iPhone52_iOS921: return 0x16;
 		case iPhone52_iOS932: return 0x16;
 		case iPhone53_iOS932: return 0x16;
 		case iPhone53_iOS933: return 0x16;
@@ -575,14 +574,14 @@ uint32_t find_pid_check(void) {
 
 uint32_t find_posix_check(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x3e;
-		case iPhone52_iOS921: return 0x3e;
 		case iPhone41_iOS921: return 0x3e;
 		case iPhone41_iOS930: return 0x3e;
 		case iPhone41_iOS931: return 0x3e;
 		case iPhone41_iOS932: return 0x3e;
 		case iPhone41_iOS933: return 0x3e;
 		case iPhone41_iOS934: return 0x3e;
+		case iPhone52_iOS920: return 0x3e;
+		case iPhone52_iOS921: return 0x3e;
 		case iPhone52_iOS932: return 0x3e;
 		case iPhone53_iOS932: return 0x3e;
 		case iPhone53_iOS933: return 0x3e;
@@ -597,8 +596,8 @@ uint32_t find_posix_check(void) {
 		case iPad22_iOS932: return 0x3e;
 		case iPad22_iOS933: return 0x3e;
 		case iPad23_iOS932: return 0x3e;
-		case iPad24_iOS932: return 0x3e;
 		case iPad23_iOS933: return 0x3e;
+		case iPad24_iOS932: return 0x3e;
 		case iPad31_iOS934: return 0x3e;
 		case iPad32_iOS931: return 0x3e;
 		case iPad33_iOS933: return 0x3e;
@@ -609,14 +608,14 @@ uint32_t find_posix_check(void) {
 
 uint32_t find_mac_proc_check(void) {
 	switch (target_environment) {
-		case iPhone52_iOS920: return 0x1e6;
-		case iPhone52_iOS921: return 0x1e6;
 		case iPhone41_iOS921: return 0x1e6;
 		case iPhone41_iOS930: return 0x1e6;
 		case iPhone41_iOS931: return 0x1e6;
 		case iPhone41_iOS932: return 0x1e6;
 		case iPhone41_iOS933: return 0x1e6;
 		case iPhone41_iOS934: return 0x1e6;
+		case iPhone52_iOS920: return 0x1e6;
+		case iPhone52_iOS921: return 0x1e6;
 		case iPhone52_iOS932: return 0x1e6;
 		case iPhone53_iOS932: return 0x1e6;
 		case iPhone53_iOS933: return 0x1e6;
@@ -631,8 +630,8 @@ uint32_t find_mac_proc_check(void) {
 		case iPad22_iOS932: return 0x1e6;
 		case iPad22_iOS933: return 0x1e6;
 		case iPad23_iOS932: return 0x1e6;
-		case iPad24_iOS932: return 0x1e6;
 		case iPad23_iOS933: return 0x1e6;
+		case iPad24_iOS932: return 0x1e6;
 		case iPad31_iOS934: return 0x1e6;
 		case iPad32_iOS931: return 0x1e6;
 		case iPad33_iOS933: return 0x1e6;

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -13,8 +13,6 @@
 
 typedef enum {
 	NotSupported,
-	iPhone52_iOS920,
-	iPhone52_iOS921,
 	iPhone41_iOS921,
 	iPhone41_iOS930,
 	iPhone41_iOS931,
@@ -22,6 +20,8 @@ typedef enum {
 	iPhone41_iOS933,
 	iPhone41_iOS934,
 	iPhone51_iOS932,
+	iPhone52_iOS920,
+	iPhone52_iOS921,
 	iPhone52_iOS932,
 	iPhone53_iOS932,
 	iPhone53_iOS933,
@@ -36,8 +36,8 @@ typedef enum {
 	iPad22_iOS932,
 	iPad22_iOS933,
 	iPad23_iOS932,
-	iPad24_iOS932,
 	iPad23_iOS933,
+	iPad24_iOS932,
 	iPad31_iOS934,
 	iPad32_iOS931,
 	iPad33_iOS933,

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -23,6 +23,7 @@ typedef enum {
 	iPhone52_iOS920,
 	iPhone52_iOS921,
 	iPhone52_iOS932,
+	iPhone53_iOS921,
 	iPhone53_iOS932,
 	iPhone53_iOS933,
     	iPad21_iOS920,


### PR DESCRIPTION
Added support for the aforementioned device combination and re-arranged some of them to fit the order better.